### PR TITLE
OpenAI API Error: replace max_token with max_completion_token

### DIFF
--- a/pages/api/analyze-pdf.js
+++ b/pages/api/analyze-pdf.js
@@ -186,7 +186,7 @@ async function callOpenAI(modelName, prompt) {
         },
         body: JSON.stringify({
             model: modelName,
-            max_tokens: 5000,
+            max_completion_tokens: 5000,
             messages: [{ role: "user", content: prompt }]
         })
     });

--- a/pages/api/score-abstracts.js
+++ b/pages/api/score-abstracts.js
@@ -83,7 +83,7 @@ async function callOpenAI(modelName, prompt) {
 
     const requestBody = {
         model: modelName,
-        max_tokens: 5000,
+        max_completion_tokens: 5000,
         messages: [{ role: "user", content: prompt }]
     };
 


### PR DESCRIPTION
For OpenAI models, the `max_tokens` option in `analyze-pdf.js` and `score-abstracts.js` should be replaced with `max_completion_tokens`