### PR TITLE
fix(analyzer): tiered session store + LLM rate-limit barrier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,29 @@ Briefings are persisted in two tiers, introduced 2026-04-21 to replace the singl
 
 **Adding a heavy field:** extend the `HEAVY_FIELDS` array in `hooks/useBriefing.js` if the new field should be strippable under quota pressure. If the field should also NOT appear in the search-capable index, extend `buildIndexEntry` in `lib/briefing/buildIndexEntry.js` to drop it.
 
+**`safeSetItem` lives in `lib/persistence/safeStorage.js`** (lifted 2026-05-07) and is shared with the analyzer session tier (next section).
+
+### Analyzer session persistence (tiered store)
+
+Same hot/cold pattern as briefings, introduced 2026-05-07 to fix a `QuotaExceededError` on 600+-paper runs. The localStorage key is unchanged (`arxivAnalyzerState`) for CLI compat.
+
+- **Hot tier (localStorage):** `arxivAnalyzerState` — built by `lib/session/buildHotEntry.js`. Carries `config`, `sessionId`, `results.finalRanking` (top 30 with `deepAnalysis`), reduced `filterResults` (counts only), `processingTiming`, `testState`, `notebookLM`, `password`. Estimated ≤ 600 KB.
+- **Cold tier (filesystem):** `reports/sessions/<sessionId>.json` via `POST /api/sessions`, `GET/DELETE /api/sessions/[id]`. Carries the full `allPapers`, `scoredPapers`, and full `filterResults.{yes,maybe,no}` arrays. Lazy-loaded by `useAnalyzerPersistence` on mount when the hot blob has a `sessionId` but no `allPapers`.
+- **No legacy migration.** Old single-key blobs are read as-is (config + finalRanking are still in the same place); next save converts to the tiered shape.
+- **CLI compat.** `cli/run-analysis.js:425, 603` and `cli/setup.js:111` continue reading `localStorage.getItem('arxivAnalyzerState')` and accessing `.config` and `.results.finalRanking`. Both fields are preserved in the hot tier.
+
+### LLM rate-limit handling
+
+All LLM-backed routes (`quick-filter`, `score-abstracts`, `rescore-abstracts`, `analyze-pdf`, `analyze-pdf-quick`, `synthesize`, `check-briefing`, `suggest-profile`) now propagate HTTP status + `Retry-After` end-to-end:
+
+- **`lib/llm/callModel.js`** throws a typed `ProviderError` (`status`, `providerErrorBody`, `retryAfterMs`) on non-2xx responses. `lib/llm/retryAfter.js` parses `Retry-After` headers (Anthropic, OpenAI) and Google's body-form `RetryInfo.retryDelay`.
+- **Each route's catch** uses `sendProviderErrorResponse(res, err)` from `lib/llm/ProviderError.js` to forward the same status + structured details (`{error, retryAfterMs, details, provider}`) to the client.
+- **`lib/analyzer/pipeline.js` clients** call `parseRouteError(response, provider)` which throws a `RateLimitError` (status + `retryAfterMs`) for 429/503 and a plain `Error(details)` for everything else — surfacing the actual provider message instead of bare "Failed to filter papers".
+- **`makeRobustAPICall`** uses exponential + jittered backoff (cap 30 s) by default, but honors `Retry-After` (cap 60 s) when a `RateLimitError` is thrown.
+- **`LLMRateLimitBarrier`** in `lib/analyzer/rateLimit.js` is shared per-provider via `getLLMBarrier(provider)`. When any worker catches a 429, it calls `barrier.rateLimited({retryAfterMs})` and every concurrent worker for that provider pauses on `barrier.acquire()` before its next call. Wired in via `AnalysisWorkerPool`'s new `barrierFor` option.
+- Default `config.maxRetries` is **4** (5 attempts total) — raised from 1 alongside the new backoff ladder.
+- Pre-flight warning fires at filter/score/rescore/pdf stage entry when free-tier Gemini Flash-Lite + concurrency × est. RPM > 60.
+
 ### ArXiv PDF Download Handling
 
 `pages/api/analyze-pdf.js` tries direct fetch first; if the response lacks `%PDF-` magic bytes, it falls back to Playwright with a persistent profile at `temp/playwright-profile/` that caches arXiv cookies + reCAPTCHA bypass state. Fallback adds ~5–10s/paper.
@@ -275,23 +298,25 @@ Two user-facing doc surfaces: README + VitePress docs at `docs/`.
 
 **Trigger → impacted docs:**
 
-| Code area                                                         | Impacted docs                                                                                                                                     |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `utils/models.js`                                                 | `concepts/model-selection.md`, `getting-started/api-keys.md`                                                                                      |
-| `lib/analyzer/pipeline.js`                                        | `concepts/pipeline.md`, `using/review-gates.md`, `using/tuning-the-pipeline.md`                                                                   |
-| `lib/arxiv/*`                                                     | `concepts/pipeline.md`, `concepts/arxiv-ingestion.md`, `using/tuning-the-pipeline.md`, `reference/troubleshooting.md`, `reference/environment.md` |
-| `prompts/synthesis.md`                                            | `concepts/briefing-anatomy.md`, `reference/prompts.md`                                                                                            |
-| Any `prompts/*.md`                                                | `reference/prompts.md`                                                                                                                            |
-| `lib/synthesis/validator.js`                                      | `concepts/briefing-anatomy.md`                                                                                                                    |
-| `pages/api/*` env usage, any new `process.env.*`                  | `reference/environment.md`                                                                                                                        |
-| `components/briefing/*`                                           | `using/reading-a-briefing.md`                                                                                                                     |
-| `components/feedback/*`                                           | `using/giving-feedback.md`                                                                                                                        |
-| `components/profile/*`, `DiffPreview.jsx`, `/api/suggest-profile` | `using/writing-a-profile.md`, `using/refining-over-time.md`                                                                                       |
-| `components/run/*` + review-gate UIs                              | `using/review-gates.md`                                                                                                                           |
-| Settings panel                                                    | `using/tuning-the-pipeline.md`                                                                                                                    |
-| `lib/notebooklm/*`                                                | `add-ons/podcast.md`                                                                                                                              |
-| `pages/api/analyze-pdf.js` Playwright changes                     | `getting-started/install.md`, `reference/troubleshooting.md`                                                                                      |
-| `pages/api/fetch-arxiv.js` query-shape or retry changes           | `getting-started/install.md` (§4 contact email), `reference/troubleshooting.md` (arXiv rate limits)                                               |
-| `hooks/useBriefing.js`, `pages/api/briefings/*`                   | `reference/environment.md` (`APARTURE_REPORTS_DIR`), `reference/troubleshooting.md` (briefing disk-write failures)                                |
+| Code area                                                                                                     | Impacted docs                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `utils/models.js`                                                                                             | `concepts/model-selection.md`, `getting-started/api-keys.md`                                                                                      |
+| `lib/analyzer/pipeline.js`                                                                                    | `concepts/pipeline.md`, `using/review-gates.md`, `using/tuning-the-pipeline.md`                                                                   |
+| `lib/arxiv/*`                                                                                                 | `concepts/pipeline.md`, `concepts/arxiv-ingestion.md`, `using/tuning-the-pipeline.md`, `reference/troubleshooting.md`, `reference/environment.md` |
+| `prompts/synthesis.md`                                                                                        | `concepts/briefing-anatomy.md`, `reference/prompts.md`                                                                                            |
+| Any `prompts/*.md`                                                                                            | `reference/prompts.md`                                                                                                                            |
+| `lib/synthesis/validator.js`                                                                                  | `concepts/briefing-anatomy.md`                                                                                                                    |
+| `pages/api/*` env usage, any new `process.env.*`                                                              | `reference/environment.md`                                                                                                                        |
+| `components/briefing/*`                                                                                       | `using/reading-a-briefing.md`                                                                                                                     |
+| `components/feedback/*`                                                                                       | `using/giving-feedback.md`                                                                                                                        |
+| `components/profile/*`, `DiffPreview.jsx`, `/api/suggest-profile`                                             | `using/writing-a-profile.md`, `using/refining-over-time.md`                                                                                       |
+| `components/run/*` + review-gate UIs                                                                          | `using/review-gates.md`                                                                                                                           |
+| Settings panel                                                                                                | `using/tuning-the-pipeline.md`                                                                                                                    |
+| `lib/notebooklm/*`                                                                                            | `add-ons/podcast.md`                                                                                                                              |
+| `pages/api/analyze-pdf.js` Playwright changes                                                                 | `getting-started/install.md`, `reference/troubleshooting.md`                                                                                      |
+| `pages/api/fetch-arxiv.js` query-shape or retry changes                                                       | `getting-started/install.md` (§4 contact email), `reference/troubleshooting.md` (arXiv rate limits)                                               |
+| `hooks/useBriefing.js`, `pages/api/briefings/*`                                                               | `reference/environment.md` (`APARTURE_REPORTS_DIR`), `reference/troubleshooting.md` (briefing disk-write failures)                                |
+| `hooks/useAnalyzerPersistence.js`, `pages/api/sessions/*`                                                     | `reference/environment.md` (`APARTURE_REPORTS_DIR`), `reference/troubleshooting.md` (session disk-write failures, browser localStorage quota)     |
+| `lib/llm/callModel.js`, `lib/llm/ProviderError.js`, `lib/llm/retryAfter.js`, `lib/analyzer/RateLimitError.js` | `reference/troubleshooting.md` (provider rate limits), `using/tuning-the-pipeline.md` (`maxRetries`, rate-limit barrier)                          |
 
 **Skip docs for:** internal refactors, bug fixes for hidden behavior, test additions, `docs/superpowers/**` changes (gitignored).

--- a/cli/config-manager.js
+++ b/cli/config-manager.js
@@ -34,8 +34,10 @@ const DEFAULT_CONFIG = {
   minAbstractScore: 7.0,
   maxPapersForPDF: 10,
 
-  // Retry/correction settings
-  maxRetries: 3,
+  // Retry/correction settings.
+  // 5 attempts (initial + 4 retries) with exponential + jittered backoff
+  // covers typical Gemini free-tier 60s RPM dips. Tunable in Settings.
+  maxRetries: 4,
   maxCorrections: 1,
 
   // NotebookLM settings

--- a/components/profile/SuggestDialog.jsx
+++ b/components/profile/SuggestDialog.jsx
@@ -179,7 +179,17 @@ export default function SuggestDialog({
         }),
       });
       if (!res.ok) {
-        throw new Error(`Suggestion failed: ${res.status}`);
+        // Surface the route's structured details (e.g. provider rate-limit
+        // message) instead of the bare HTTP code.
+        let bodyMsg = `Suggestion failed: ${res.status}`;
+        try {
+          const errBody = await res.json();
+          if (errBody?.details) bodyMsg = errBody.details;
+          else if (errBody?.error) bodyMsg = errBody.error;
+        } catch {
+          // body wasn't JSON — keep the status-based message
+        }
+        throw new Error(bodyMsg);
       }
       const data = await res.json();
       setResponse(data);

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -139,6 +139,8 @@ The stage runs with a worker pool. PDF downloads are serialised server-side (~5 
 
 On **Anthropic** providers, the pool applies a cache-warmup barrier: the first worker finishes its call alone so the ephemeral prompt-cache entry is primed once, and the remaining workers then start and hit the cache on every subsequent paper. This costs a few extra seconds on the first paper in exchange for a large input-token discount on the rest. Google and OpenAI have no warmup — all workers start immediately.
 
+Across all LLM stages (filter, score, post-process, PDF analysis, briefing), Aparture maintains a per-provider rate-limit barrier: when any worker catches a 429 or 503, all concurrent workers for that provider pause until the provider-signaled `Retry-After` elapses (capped at 60 s). This prevents cascading 429s when one of N parallel batches trips the project's RPM cap — Gemini's free-tier 60 RPM in particular.
+
 **Inputs.** Top N papers from Stage 3.5, `profile.content`, `pdfModel` (default `gemini-3.1-pro`), `pdfAnalysisConcurrency` (default 3).
 
 **Output.** `finalRanking` — papers augmented with `deepAnalysis`, `finalScore`, `preAnalysisScore`, and `pdfScoreAdjustment`.

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -105,7 +105,12 @@ Institutional addresses (`.edu`, `.ac.*`) tend to carry more weight than generic
 
 ### `APARTURE_REPORTS_DIR`
 
-Base directory for runtime-state files. Today the briefing persistence layer writes to `<APARTURE_REPORTS_DIR>/briefings/<id>.json`; future runtime outputs may live alongside. Defaults to `<cwd>/reports`, matching the existing `reports/` convention.
+Base directory for runtime-state files. Today two persistence layers write here:
+
+- briefing tier writes to `<APARTURE_REPORTS_DIR>/briefings/<id>.json`,
+- analyzer session tier writes to `<APARTURE_REPORTS_DIR>/sessions/<sessionId>.json` (full `allPapers` + `scoredPapers` + filter verdicts; the localStorage hot blob keeps only a summary so quota is never the limit).
+
+Defaults to `<cwd>/reports`, matching the existing `reports/` convention.
 
 ```bash
 # .env.local (rarely set in practice)

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -246,6 +246,22 @@ Common causes:
 - **`APARTURE_REPORTS_DIR` points somewhere invalid.** Unset it or confirm the path exists and is writable.
 - **`ACCESS_PASSWORD` not set or mismatched.** The POST auth check is the same as every other API route — if the server log shows `401 Invalid password` on `POST /api/briefings`, rotate the env var and restart `npm run dev`.
 
+### Session disk writes failing
+
+```
+[useAnalyzerPersistence] failed to persist session to disk: <reason>
+```
+
+Analyzer session state (full `allPapers` + `scoredPapers` + filter verdicts) is written to `reports/sessions/<sessionId>.json` via `POST /api/sessions` on every debounced save. The hot tier (localStorage `arxivAnalyzerState`) carries only a small summary — `config`, `finalRanking` (top 30), and filter counts — so the live UI keeps working even when the cold tier write fails. After a page refresh, however, the cold tier is consulted to restore `allPapers`/`scoredPapers`; if it's missing, the page renders with the summary only.
+
+Same fixes as briefings disk writes (permissions, disk full, `APARTURE_REPORTS_DIR`, `ACCESS_PASSWORD`).
+
+### Browser localStorage quota
+
+Symptom (pre-2026-05-07 builds): a `QuotaExceededError` from `useAnalyzerPersistence` would surface as a Next.js red box and abort the run. Current builds catch this transparently via the `safeSetItem` ladder shared with the briefings tier — heavy session fields live on the filesystem, the localStorage hot blob stays under ~600 KB, and quota pressure logs a single `console.warn` without disrupting the run.
+
+If you still see the warning repeatedly, you likely have a very old `arxivAnalyzerState` blob from a previous Aparture install that's not being shrunk. Clear it: in DevTools console run `localStorage.removeItem('arxivAnalyzerState')` and refresh.
+
 ### arXiv rate limits
 
 ```
@@ -317,6 +333,19 @@ See [Install → Playwright](/getting-started/install#_5-playwright-optional-fal
 
 ### Provider rate limits
 
+Aparture honors `Retry-After` from every provider and pauses ALL concurrent
+workers for the same provider when one batch trips a 429 (Gemini's RPM cap is
+project-scoped, so siblings are about to trip too). The retry ladder uses
+exponential backoff with ±20 % jitter capped at 30 s, with up to
+`maxRetries` retries (default 4 → 5 attempts). On a 429 with `Retry-After`,
+the ladder honors that value first (capped at 60 s). End-of-stage activity-log
+lines call out how many batches were rate-limited so you know whether to
+adjust concurrency or upgrade tier.
+
+If you're on a free-tier Google key, Aparture also emits a pre-flight warning
+when the configured concurrency × batch count is likely to exceed 60 RPM —
+the run still proceeds and self-heals via the barrier, but expect more retries.
+
 Each provider has several flavours of 429, each with its own fix.
 
 **Anthropic 429** (`anthropic request failed (429)`).
@@ -327,7 +356,7 @@ Each provider has several flavours of 429, each with its own fix.
 
 **OpenAI 429** (`openai request failed (429)`).
 
-- _"Rate limit reached for requests"_ — transient. Aparture's client-side retry loop handles this automatically up to 3 times.
+- _"Rate limit reached for requests"_ — transient. Aparture's client-side retry loop handles this automatically up to `maxRetries` times (default 4) with exponential backoff + provider `Retry-After` honoring.
 - _"You exceeded your current quota"_ — billing issue, not transient. Check usage limits and billing status at [platform.openai.com](https://platform.openai.com).
 
 Free-tier OpenAI accounts (approximately 3 RPM on GPT-5.4-class models) will 429 on almost any real run. Move to a paid tier before attempting more than the Minimal API Test.

--- a/docs/using/tuning-the-pipeline.md
+++ b/docs/using/tuning-the-pipeline.md
@@ -89,6 +89,8 @@ Same Anthropic cache-warmup behavior as filter.
 
 Three is a conservative default that works across provider tiers. Raising it to 5–8 is usually fine on higher provider tiers (Anthropic Tier 3+, Google Tier 2+, OpenAI Tier 3+); drop to 1 if you start seeing 429s on a rate-limit-sensitive tier. Free-tier Google has aggressive RPM caps on Flash-Lite, so start at 2–3 if you're relying on the free tier for filtering.
 
+Aparture self-heals on transient 429s: when one batch hits a rate limit, every concurrent worker for the same provider pauses for the `Retry-After` window (or up to 60 s if the provider doesn't tell us), then retries. The retry ladder uses up to `maxRetries` retries (default 4 → 5 attempts) with exponential + jittered backoff. End-of-stage activity-log lines call out how many batches were rate-limited so you can see whether to drop concurrency or upgrade tier. If your filter model is a free-tier Gemini Flash-Lite slot and your concurrency × batch count is likely to exceed 60 RPM, Aparture also emits a pre-flight warning before the stage starts.
+
 ## Batch sizes
 
 Each stage batches papers into API calls to avoid per-paper overhead. Bigger batches are faster but risk hitting context limits or giving each paper less careful attention.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,8 @@ export default [
         DOMParser: 'readonly',
         XPathResult: 'readonly',
         AbortController: 'readonly',
+        DOMException: 'readonly',
+        Storage: 'readonly',
         // Node.js globals
         process: 'readonly',
         __dirname: 'readonly',

--- a/hooks/useAnalyzerPersistence.js
+++ b/hooks/useAnalyzerPersistence.js
@@ -324,7 +324,11 @@ export function useAnalyzerPersistence({
         // Merge cold heavy fields into the existing hot finalRanking so
         // we don't overwrite it with whatever the cold tier had (cold may
         // be slightly stale if save was mid-flight at refresh time).
+        // Spread `prev` and `cold.results` so non-canonical slice fields
+        // (e.g. `failedPapers` from scoreAbstracts) survive the round-trip.
         setResults((prev) => ({
+          ...(prev ?? {}),
+          ...(cold.results ?? {}),
           allPapers: cold.results?.allPapers ?? [],
           scoredPapers: cold.results?.scoredPapers ?? [],
           finalRanking: prev?.finalRanking?.length

--- a/hooks/useAnalyzerPersistence.js
+++ b/hooks/useAnalyzerPersistence.js
@@ -6,12 +6,27 @@
 //   used as useState(readInitialConfig) so hooks that depend on config see
 //   the real persisted values on first render, not the hardcoded default).
 // - The on-mount load effect that restores non-config state.
-// - The debounced save effect that writes the full session snapshot.
+// - The debounced save effect that writes a tiered session snapshot:
+//   hot tier (localStorage, capped ~600KB via buildHotEntry) + cold tier
+//   (filesystem via POST /api/sessions, full results + filter verdicts).
+//
+// Tiered store mirrors hooks/useBriefing.js (briefings tier shipped 2026-04-21).
+// Heavy fields (results.allPapers, results.scoredPapers, full filterResults
+// arrays) are dropped from the hot blob — they live only on disk now.
 
 import { useEffect, useRef } from 'react';
+import { safeSetItem } from '../lib/persistence/safeStorage.js';
+import { buildHotEntry, buildColdEntry } from '../lib/session/buildHotEntry.js';
 
 const STORAGE_KEY = 'arxivAnalyzerState';
 const SAVE_DEBOUNCE_MS = 400;
+
+function generateSessionId() {
+  if (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `sess-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
 
 export const DEFAULT_CONFIG = {
   version: 6,
@@ -55,7 +70,10 @@ export const DEFAULT_CONFIG = {
   daysBack: 1,
   batchSize: 3,
   maxCorrections: 1,
-  maxRetries: 1,
+  // 5 attempts (initial + 4 retries) with exponential + jittered backoff in
+  // makeRobustAPICall covers a ~31s quota dip — well within Gemini's 60s
+  // RPM reset window. Tunable via Settings.
+  maxRetries: 4,
   useQuickFilter: true,
   filterModel: 'gemini-3.1-flash-lite',
   filterBatchSize: 3,
@@ -192,6 +210,23 @@ export function readInitialConfig() {
   }
 }
 
+// Lazy-fetch the cold-tier session payload by id. Returns null on any
+// failure (404, network, parse) so the load effect can fall through to
+// the hot-tier-only state.
+async function fetchColdSession(sessionId, password) {
+  if (!sessionId) return null;
+  try {
+    const res = await fetch(
+      `/api/sessions/${encodeURIComponent(sessionId)}?password=${encodeURIComponent(password ?? '')}`
+    );
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.warn('[useAnalyzerPersistence] failed to load cold session:', err);
+    return null;
+  }
+}
+
 export function useAnalyzerPersistence({
   // state values (for save)
   config,
@@ -215,56 +250,117 @@ export function useAnalyzerPersistence({
   setPassword,
   setIsAuthenticated,
 }) {
+  // Persistent session id. Read from the hot blob on first load if present;
+  // otherwise lazily generated on the first save. Survives renders via ref.
+  const sessionIdRef = useRef(null);
+
   // Load on mount. Config is already restored by readInitialConfig at
   // useState init time, so this effect only restores non-config state.
+  // Two paths:
+  //   1) New (tiered) blob — hot tier carries finalRanking + filter counts;
+  //      full allPapers/scoredPapers/verdicts come from cold tier via fetch.
+  //   2) Legacy blob — full results + filterResults inline; restored as-is.
+  //      No migration: next save converts to tiered shape.
   useEffect(() => {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return;
+    let parsed;
     try {
-      const parsed = JSON.parse(raw);
-      if (parsed.results) setResults(parsed.results);
-      if (parsed.filterResults) {
-        // Restore persisted verdicts; reset transient progress fields so a
-        // refresh mid-run doesn't strand the UI in an 'inProgress' state.
-        setFilterResults({
-          total: parsed.filterResults.total ?? 0,
-          yes: parsed.filterResults.yes ?? [],
-          maybe: parsed.filterResults.maybe ?? [],
-          no: parsed.filterResults.no ?? [],
-          inProgress: false,
-          currentBatch: 0,
-          totalBatches: 0,
-        });
-      }
-      if (parsed.processingTiming) {
-        const timing = { ...parsed.processingTiming };
-        if (timing.startTime) timing.startTime = new Date(timing.startTime);
-        if (timing.endTime) timing.endTime = new Date(timing.endTime);
-        setProcessingTiming(timing);
-      }
-      if (parsed.testState) setTestState(parsed.testState);
-      if (parsed.notebookLM) {
-        if (parsed.notebookLM.duration) setPodcastDuration(parsed.notebookLM.duration);
-        if (parsed.notebookLM.model) setNotebookLMModel(parsed.notebookLM.model);
-        if (parsed.notebookLM.content) setNotebookLMContent(parsed.notebookLM.content);
-      }
-      if (parsed.password) {
-        setPassword(parsed.password);
-        setIsAuthenticated(true);
-      }
+      parsed = JSON.parse(raw);
     } catch (e) {
-      console.error('Failed to load saved state:', e);
+      console.error('Failed to parse saved analyzer state:', e);
+      return;
+    }
+
+    // Adopt the hot blob's sessionId if present so subsequent saves write
+    // back to the same cold-tier file.
+    if (parsed.sessionId) sessionIdRef.current = parsed.sessionId;
+
+    // Restore hot-tier fields synchronously. Legacy blobs carry full results
+    // here; new blobs carry only finalRanking. Either way, this is what the
+    // first render sees.
+    if (parsed.results) setResults(parsed.results);
+    if (parsed.filterResults) {
+      // Legacy blob has yes/maybe/no arrays; tiered blob has only counts.
+      // Either way, reset transient progress fields so a refresh mid-run
+      // doesn't strand the UI in an 'inProgress' state.
+      setFilterResults({
+        total: parsed.filterResults.total ?? 0,
+        yes: parsed.filterResults.yes ?? [],
+        maybe: parsed.filterResults.maybe ?? [],
+        no: parsed.filterResults.no ?? [],
+        inProgress: false,
+        currentBatch: 0,
+        totalBatches: 0,
+      });
+    }
+    if (parsed.processingTiming) {
+      const timing = { ...parsed.processingTiming };
+      if (timing.startTime) timing.startTime = new Date(timing.startTime);
+      if (timing.endTime) timing.endTime = new Date(timing.endTime);
+      setProcessingTiming(timing);
+    }
+    if (parsed.testState) setTestState(parsed.testState);
+    if (parsed.notebookLM) {
+      if (parsed.notebookLM.duration) setPodcastDuration(parsed.notebookLM.duration);
+      if (parsed.notebookLM.model) setNotebookLMModel(parsed.notebookLM.model);
+      if (parsed.notebookLM.content) setNotebookLMContent(parsed.notebookLM.content);
+    }
+    if (parsed.password) {
+      setPassword(parsed.password);
+      setIsAuthenticated(true);
+    }
+
+    // Tiered blob with sessionId but missing heavy fields → fetch cold tier.
+    // Detection: hot blob says sessionId + no allPapers/scoredPapers in
+    // results. Legacy blobs always have allPapers if they have results, so
+    // they don't trigger the fetch.
+    const hotHasHeavy =
+      (parsed.results?.allPapers?.length ?? 0) > 0 ||
+      (parsed.results?.scoredPapers?.length ?? 0) > 0;
+    if (parsed.sessionId && !hotHasHeavy) {
+      fetchColdSession(parsed.sessionId, parsed.password).then((cold) => {
+        if (!cold) return;
+        // Merge cold heavy fields into the existing hot finalRanking so
+        // we don't overwrite it with whatever the cold tier had (cold may
+        // be slightly stale if save was mid-flight at refresh time).
+        setResults((prev) => ({
+          allPapers: cold.results?.allPapers ?? [],
+          scoredPapers: cold.results?.scoredPapers ?? [],
+          finalRanking: prev?.finalRanking?.length
+            ? prev.finalRanking
+            : (cold.results?.finalRanking ?? []),
+        }));
+        if (cold.filterResults) {
+          setFilterResults((prev) => ({
+            total: cold.filterResults.total ?? prev.total ?? 0,
+            yes: cold.filterResults.yes ?? [],
+            maybe: cold.filterResults.maybe ?? [],
+            no: cold.filterResults.no ?? [],
+            inProgress: false,
+            currentBatch: 0,
+            totalBatches: 0,
+          }));
+        }
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Debounced save. A trailing 400ms debounce stops ~167 sequential
   // stringifies during a 500-paper filter batch loop.
+  //
+  // Two tiers per save:
+  //   1) Hot (localStorage): buildHotEntry → safeSetItem. Stays under quota
+  //      because allPapers/scoredPapers/full verdicts are excluded.
+  //   2) Cold (filesystem): buildColdEntry → fire-and-forget POST. Best
+  //      effort; failures log but don't disrupt the live run.
   const saveTimeoutRef = useRef(null);
   useEffect(() => {
     const hasResults =
       (results?.allPapers?.length ?? 0) > 0 ||
       (results?.scoredPapers?.length ?? 0) > 0 ||
+      (results?.finalRanking?.length ?? 0) > 0 ||
       (filterResults?.yes?.length ?? 0) > 0 ||
       (filterResults?.maybe?.length ?? 0) > 0 ||
       (filterResults?.no?.length ?? 0) > 0;
@@ -272,27 +368,50 @@ export function useAnalyzerPersistence({
 
     if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     saveTimeoutRef.current = setTimeout(() => {
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({
-          config,
+      // Lazy session-id allocation. Subsequent saves reuse the same id so
+      // the cold-tier file is overwritten in place rather than churning.
+      if (!sessionIdRef.current) sessionIdRef.current = generateSessionId();
+      const sessionId = sessionIdRef.current;
+
+      // Hot tier — bounded blob, safe under localStorage quota.
+      const hotEntry = buildHotEntry({
+        config,
+        sessionId,
+        finalRanking: results?.finalRanking,
+        filterResults,
+        processingTiming,
+        testState,
+        podcastDuration,
+        notebookLMModel,
+        notebookLMContent,
+        password,
+        isAuthenticated,
+      });
+      const ok = safeSetItem(STORAGE_KEY, JSON.stringify(hotEntry));
+      if (!ok) {
+        console.warn(
+          '[useAnalyzerPersistence] localStorage quota exceeded; analyzer state could not be persisted (in-memory state preserved for this session)'
+        );
+      }
+
+      // Cold tier — full payload, only POSTed when there's actual results
+      // worth shipping to disk. Skips empty saves (password-only changes
+      // don't need a cold write). Best-effort.
+      if (hasResults && isAuthenticated && password) {
+        const coldEntry = buildColdEntry({
+          sessionId,
           results,
-          filterResults: {
-            total: filterResults.total,
-            yes: filterResults.yes,
-            maybe: filterResults.maybe,
-            no: filterResults.no,
-          },
+          filterResults,
           processingTiming,
-          testState,
-          notebookLM: {
-            duration: podcastDuration,
-            model: notebookLMModel,
-            content: notebookLMContent,
-          },
-          password: isAuthenticated ? password : '',
-        })
-      );
+        });
+        fetch('/api/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ password, entry: coldEntry }),
+        }).catch((err) => {
+          console.warn('[useAnalyzerPersistence] failed to persist session to disk:', err);
+        });
+      }
     }, SAVE_DEBOUNCE_MS);
 
     return () => {

--- a/hooks/useBriefing.js
+++ b/hooks/useBriefing.js
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { buildIndexEntry } from '../lib/briefing/buildIndexEntry.js';
+import { safeSetItem } from '../lib/persistence/safeStorage.js';
 
 const CURRENT_KEY = 'aparture-briefing-current';
 const HISTORY_KEY = 'aparture-briefing-index';
@@ -12,33 +13,10 @@ const MAX_HISTORY = 90;
 // briefing readable.
 const HEAVY_FIELDS = ['pipelineArchive', 'quickSummariesById', 'fullReportsById'];
 
-function isQuotaError(err) {
-  if (!err) return false;
-  // Name varies across browsers; numeric codes 22 / 1014 are the legacy forms.
-  const name = err.name || '';
-  return (
-    name === 'QuotaExceededError' ||
-    name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
-    err.code === 22 ||
-    err.code === 1014
-  );
-}
-
 function stripHeavy(entry) {
   const out = { ...entry };
   for (const key of HEAVY_FIELDS) delete out[key];
   return out;
-}
-
-function safeSetItem(key, value) {
-  if (typeof window === 'undefined') return true;
-  try {
-    window.localStorage.setItem(key, value);
-    return true;
-  } catch (err) {
-    if (isQuotaError(err)) return false;
-    throw err;
-  }
 }
 
 // Persist a newest-first array of briefings. On quota, prune oldest entries

--- a/lib/analyzer/RateLimitError.js
+++ b/lib/analyzer/RateLimitError.js
@@ -1,0 +1,53 @@
+// Client-side typed error for rate-limit (HTTP 429) and overloaded (503)
+// responses from the LLM-backed API routes. Carries the provider's
+// Retry-After hint (ms) so makeRobustAPICall can sleep for the right
+// duration AND signal the per-provider LLMRateLimitBarrier so concurrent
+// workers pause too.
+
+export class RateLimitError extends Error {
+  constructor({ provider, status, retryAfterMs, message }) {
+    super(message ?? `${provider}: rate limited (${status})`);
+    this.name = 'RateLimitError';
+    this.provider = provider;
+    this.status = status;
+    this.retryAfterMs = retryAfterMs ?? null;
+  }
+}
+
+// Read a non-OK route response and throw a typed error. Used by every
+// pipeline stage's `if (!response.ok)` branch so error surfacing is uniform.
+//
+// 429/503 → RateLimitError (carries provider + retryAfterMs from the route's
+// structured body, populated by sendProviderErrorResponse upstream).
+// All other statuses → plain Error with the route's `details` string —
+// which now contains the actual provider message ("google: invalid argument",
+// "anthropic: prompt too long") instead of the bare "Failed to filter papers"
+// from the legacy generic 500 catch.
+export async function parseRouteError(response, fallbackProvider) {
+  let body = {};
+  try {
+    body = await response.json();
+  } catch {
+    // Non-JSON body — keep the empty object; status code below provides context.
+  }
+
+  const provider = body.provider ?? fallbackProvider ?? 'llm';
+
+  if (response.status === 429 || response.status === 503) {
+    const retryAfterMs = body.retryAfterMs ?? null;
+    const suffix = retryAfterMs
+      ? ` — retry in ${Math.max(1, Math.round(retryAfterMs / 1000))}s`
+      : '';
+    throw new RateLimitError({
+      provider,
+      status: response.status,
+      retryAfterMs,
+      message: `${provider}: rate limited (${response.status})${suffix}`,
+    });
+  }
+
+  // Prefer details (the actual provider message) over the route's `error`
+  // (which is a generic "Failed to filter papers" string for legacy callers).
+  const message = body.details || body.error || `${provider} request failed (${response.status})`;
+  throw new Error(message);
+}

--- a/lib/analyzer/briefingClient.js
+++ b/lib/analyzer/briefingClient.js
@@ -8,6 +8,7 @@
 
 import { MODEL_REGISTRY } from '../../utils/models.js';
 import { composeFullReport } from './composeFullReport.js';
+import { parseRouteError } from './RateLimitError.js';
 
 const LAST_RUN_CACHE_KEY = 'aparture-last-analysis-run';
 
@@ -118,9 +119,12 @@ async function callSynthesize({ profile, papers, provider, modelId, password, re
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
-  const json = await res.json();
-  if (!res.ok) throw new Error(json.error ?? 'synthesis failed');
-  return json;
+  if (!res.ok) {
+    // Surfaces actual provider message (e.g. "google: rate limited (429) — retry in 23s")
+    // instead of the bare "synthesis failed".
+    await parseRouteError(res, provider);
+  }
+  return await res.json();
 }
 
 // Hallucination check is non-fatal: if the route fails we return null so

--- a/lib/analyzer/pipeline.js
+++ b/lib/analyzer/pipeline.js
@@ -12,9 +12,34 @@ import { MockAPITester } from './mockApi.js';
 import { TEST_PAPERS } from '../../utils/testUtils.js';
 import { useAnalyzerStore } from '../../stores/analyzerStore.js';
 import { MODEL_REGISTRY } from '../../utils/models.js';
-import { AnalysisWorkerPool } from './rateLimit.js';
+import { AnalysisWorkerPool, getLLMBarrier } from './rateLimit.js';
+import { RateLimitError, parseRouteError } from './RateLimitError.js';
 import { extractJsonFromLlmOutput } from '../../utils/json.js';
 import { harvest } from '../arxiv/ingest.js';
+
+// Pre-flight free-tier RPM warning. Aparture's default Google Flash-Lite
+// slot is on the free 60 RPM cap; with concurrency × estimated batches/sec
+// > 60, users see cascading 429s. The barrier auto-recovers but the run
+// is much slower, so warn proactively.
+function warnIfFreeTierLikelyToThrottle({
+  provider,
+  model,
+  concurrency,
+  totalBatches,
+  addStatus,
+  stageLabel,
+}) {
+  if (provider !== 'google') return;
+  if (typeof model !== 'string' || !model.includes('flash-lite')) return;
+  // Conservative: assume ~2s per Flash-Lite call. concurrency=3 → 90 RPM.
+  const estimatedRPM = concurrency * 30;
+  if (estimatedRPM <= 60) return;
+  if (totalBatches < 20) return; // small runs won't sustain the rate long enough
+  addStatus(
+    `Warning: ${stageLabel} may exceed Gemini free-tier 60 RPM (concurrency=${concurrency}, ` +
+      `~${estimatedRPM} req/min estimated). The pipeline auto-pauses on 429s but expect retries to slow the run.`
+  );
+}
 
 export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITesterRef }) {
   const store = () => useAnalyzerStore.getState();
@@ -126,14 +151,33 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
         if (apiError?.code === 'PLAYWRIGHT_UNAVAILABLE_RECAPTCHA') {
           throw apiError;
         }
+
+        // Rate-limit cascade: signal the per-provider barrier so siblings
+        // pause too. Gemini's RPM cap is project-scoped — when one worker
+        // trips it, the others are about to trip the same limit.
+        if (apiError instanceof RateLimitError) {
+          const fallbackMs = apiError.retryAfterMs ?? 5000;
+          getLLMBarrier(apiError.provider).rateLimited({ retryAfterMs: fallbackMs });
+        }
+
         lastError = apiError;
         if (retryCount < config.maxRetries) {
           addStatus(
             `${context} - API call failed, retrying ${retryCount + 1}/${config.maxRetries}: ${apiError.message}`
           );
 
+          // Backoff: prefer provider's Retry-After (cap 60s); else
+          // exponential 1s/2s/4s/... capped 30s with ±20% jitter.
+          let delay;
+          if (apiError instanceof RateLimitError && apiError.retryAfterMs) {
+            delay = Math.min(60000, apiError.retryAfterMs);
+          } else {
+            const base = Math.min(30000, 1000 * Math.pow(2, retryCount));
+            const jitter = base * (0.8 + 0.4 * Math.random());
+            delay = Math.round(jitter);
+          }
+
           // Sleep with abort checking
-          const delay = 1000;
           for (let i = 0; i < delay; i += 50) {
             if (abortControllerRef.current?.signal.aborted) {
               throw new Error('Operation aborted');
@@ -364,14 +408,32 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
     const providerLower = (MODEL_REGISTRY[config.filterModel]?.provider ?? '').toLowerCase();
     const shouldWarmupCache = !isDryRun && providerLower === 'anthropic';
 
+    // Pre-flight warning when free-tier Gemini Flash-Lite × concurrency is
+    // likely to trigger 429 cascades. Cheap UX win.
+    if (!isDryRun) {
+      warnIfFreeTierLikelyToThrottle({
+        provider: providerLower,
+        model: config.filterModel,
+        concurrency,
+        totalBatches,
+        addStatus: store().addStatus,
+        stageLabel: 'Stage 2 filter',
+      });
+    }
+
     const filterPool = new AnalysisWorkerPool({
       concurrency,
       cacheWarmup: shouldWarmupCache,
       abortSignal: abortControllerRef.current?.signal,
+      // Per-provider rate-limit barrier: when one batch hits 429, all
+      // siblings pause for the Retry-After window. Live runs only — dry-run
+      // doesn't hit a real provider.
+      barrierFor: !isDryRun ? () => getLLMBarrier(providerLower) : null,
     });
 
     let completedBatches = 0;
     let papersProcessed = 0;
+    let rateLimitedBatches = 0;
 
     await filterPool.run(batches, async (batch, batchIndex) => {
       if (abortControllerRef.current?.signal.aborted) {
@@ -431,17 +493,10 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
             });
 
             if (!response.ok) {
-              // Match the score/rescore client pattern: parse the structured
-              // JSON error body so we surface the route's `error` field
-              // directly rather than a stringified blob.
-              let errorMessage = `Filter API error: ${response.status}`;
-              try {
-                const errorData = await response.json();
-                if (errorData?.error) errorMessage = errorData.error;
-              } catch {
-                // Body wasn't JSON — keep the generic status-based message.
-              }
-              throw new Error(errorMessage);
+              // 429/503 → RateLimitError (with retryAfterMs from the route).
+              // Other non-OK → Error with the route's actual `details`
+              // string ("google: invalid argument") instead of a generic blob.
+              await parseRouteError(response, providerLower);
             }
 
             const data = await response.json();
@@ -510,6 +565,7 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
         if (error.message === 'Operation aborted') {
           throw error;
         }
+        if (error instanceof RateLimitError) rateLimitedBatches += 1;
         addError(`Filter batch ${batchIndex + 1} failed: ${error.message}`);
         // On failure, include all papers in batch as MAYBE (safe default)
         batch.forEach((paper) => {
@@ -542,6 +598,14 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
     console.log(`MAYBE: ${maybeCount} (${Math.round((maybeCount / papers.length) * 100)}%)`);
     console.log(`NO: ${noCount} (${Math.round((noCount / papers.length) * 100)}%)`);
     console.log(`Papers proceeding to scoring: ${filteredPapers.length}`);
+
+    // End-of-stage summary in the activity log. Surfaces rate-limit count
+    // separately so users can distinguish "free-tier RPM cap" from harder
+    // failures (validation, auth, etc.).
+    const rlSuffix = rateLimitedBatches > 0 ? `, ${rateLimitedBatches} rate-limited` : '';
+    store().addStatus(
+      `Filter complete: ${completedBatches}/${totalBatches} batches succeeded${rlSuffix}`
+    );
 
     return filteredPapers;
   };
@@ -602,13 +666,26 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
     const providerLower = (MODEL_REGISTRY[config.scoringModel]?.provider ?? '').toLowerCase();
     const shouldWarmupCache = !isDryRun && providerLower === 'anthropic';
 
+    if (!isDryRun) {
+      warnIfFreeTierLikelyToThrottle({
+        provider: providerLower,
+        model: config.scoringModel,
+        concurrency,
+        totalBatches: batches.length,
+        addStatus: store().addStatus,
+        stageLabel: 'Stage 2 scoring',
+      });
+    }
+
     const scoringPool = new AnalysisWorkerPool({
       concurrency,
       cacheWarmup: shouldWarmupCache,
       abortSignal: abortControllerRef.current?.signal,
+      barrierFor: !isDryRun ? () => getLLMBarrier(providerLower) : null,
     });
 
     let papersProcessed = 0;
+    let rateLimitedBatches = 0;
 
     await scoringPool.run(batches, async (batch, batchIndex) => {
       if (abortControllerRef.current?.signal.aborted) {
@@ -692,8 +769,7 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
             });
 
             if (!response.ok) {
-              const errorData = await response.json();
-              throw new Error(errorData.error || `API error: ${response.status}`);
+              await parseRouteError(response, providerLower);
             }
 
             const data = await response.json();
@@ -779,6 +855,7 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
           throw error;
         }
 
+        if (error instanceof RateLimitError) rateLimitedBatches += 1;
         addError(`Failed to score batch ${batchIndex + 1} after all retries: ${error.message}`);
 
         // Add failed papers to the failed list, not the main results
@@ -823,6 +900,10 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
         `Warning: ${failedPapers.length} papers failed to score and will be excluded from deep analysis`
       );
     }
+    const rlSuffix = rateLimitedBatches > 0 ? `, ${rateLimitedBatches} rate-limited` : '';
+    addStatus(
+      `Scoring complete: ${scoredPapers.length} scored, ${failedPapers.length} failed${rlSuffix}`
+    );
 
     const finalSorted = [...scoredPapers].sort((a, b) => b.relevanceScore - a.relevanceScore);
     return finalSorted;
@@ -885,9 +966,11 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
       concurrency,
       cacheWarmup: shouldWarmupCache,
       abortSignal: abortControllerRef.current?.signal,
+      barrierFor: !isDryRun ? () => getLLMBarrier(providerLower) : null,
     });
 
     let papersProcessed = 0;
+    let rateLimitedBatches = 0;
 
     await rescorePool.run(batches, async (batch, batchIndex) => {
       if (abortControllerRef.current?.signal.aborted) {
@@ -978,8 +1061,7 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
             });
 
             if (!response.ok) {
-              const errorData = await response.json();
-              throw new Error(errorData.error || `API error: ${response.status}`);
+              await parseRouteError(response, providerLower);
             }
 
             const data = await response.json();
@@ -1038,6 +1120,7 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
           throw error;
         }
 
+        if (error instanceof RateLimitError) rateLimitedBatches += 1;
         addError(`Failed to rescore batch ${batchIndex + 1}: ${error.message}`);
 
         // Keep original scores for failed batch
@@ -1080,6 +1163,12 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
       (p) => p.scoreAdjustment && Math.abs(p.scoreAdjustment) > 0.1
     ).length;
     console.log(`Papers with adjusted scores: ${adjustedCount}`);
+    {
+      const rlSuffix = rateLimitedBatches > 0 ? `, ${rateLimitedBatches} rate-limited` : '';
+      store().addStatus(
+        `Post-processing complete: ${processedPapers.length} processed, ${adjustedCount} adjusted${rlSuffix}`
+      );
+    }
 
     // Persist the final post-processed list back to scoredPapers so the
     // abstract-only view (computed as scoredPapers minus finalRanking)
@@ -1123,7 +1212,10 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
       concurrency,
       cacheWarmup: shouldWarmupCache,
       abortSignal: abortControllerRef.current?.signal,
+      barrierFor: !isDryRun ? () => getLLMBarrier(providerLower) : null,
     });
+
+    let rateLimitedPapers = 0;
 
     const runSingle = async (paper, idx) => {
       if (abortControllerRef.current?.signal.aborted) return;
@@ -1193,18 +1285,20 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
             });
 
             if (!response.ok) {
-              const errorData = await response.json();
-              if (
-                response.status === 422 &&
-                errorData?.error === 'PLAYWRIGHT_UNAVAILABLE_RECAPTCHA'
-              ) {
-                const skipErr = new Error('PLAYWRIGHT_UNAVAILABLE_RECAPTCHA');
-                skipErr.code = 'PLAYWRIGHT_UNAVAILABLE_RECAPTCHA';
-                skipErr.arxivId = errorData.arxivId ?? paper.arxivId ?? paper.id;
-                skipErr.title = errorData.title ?? paper.title;
-                throw skipErr;
+              // 422 PLAYWRIGHT_UNAVAILABLE_RECAPTCHA needs special handling
+              // (skip-and-continue, not retry); read body once, dispatch.
+              if (response.status === 422) {
+                const errorData = await response.json().catch(() => ({}));
+                if (errorData?.error === 'PLAYWRIGHT_UNAVAILABLE_RECAPTCHA') {
+                  const skipErr = new Error('PLAYWRIGHT_UNAVAILABLE_RECAPTCHA');
+                  skipErr.code = 'PLAYWRIGHT_UNAVAILABLE_RECAPTCHA';
+                  skipErr.arxivId = errorData.arxivId ?? paper.arxivId ?? paper.id;
+                  skipErr.title = errorData.title ?? paper.title;
+                  throw skipErr;
+                }
+                throw new Error(errorData.error || `API error: ${response.status}`);
               }
-              throw new Error(errorData.error || `API error: ${response.status}`);
+              await parseRouteError(response, providerLower);
             }
 
             const data = await response.json();
@@ -1329,6 +1423,7 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
           return;
         }
 
+        if (error instanceof RateLimitError) rateLimitedPapers += 1;
         addError(`Failed to analyze paper "${paper.title}" after all retries: ${error.message}`);
         analyzedPapers[idx] = {
           ...paper,
@@ -1346,7 +1441,13 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
     await pool.run(papers, runSingle);
 
     // Filter holes in case abort left unclaimed papers undefined.
-    return analyzedPapers.filter((p) => p !== undefined);
+    const finalPapers = analyzedPapers.filter((p) => p !== undefined);
+    const succeeded = finalPapers.filter((p) => p?.deepAnalysis).length;
+    const rlSuffix = rateLimitedPapers > 0 ? `, ${rateLimitedPapers} rate-limited` : '';
+    store().addStatus(
+      `PDF analysis complete: ${succeeded}/${papers.length} papers analyzed${rlSuffix}`
+    );
+    return finalPapers;
   };
 
   const startProcessing = async (isDryRun = false, useTestPapers = false) => {

--- a/lib/analyzer/pipeline.js
+++ b/lib/analyzer/pipeline.js
@@ -168,8 +168,10 @@ export function createAnalysisPipeline({ abortControllerRef, pauseRef, mockAPITe
 
           // Backoff: prefer provider's Retry-After (cap 60s); else
           // exponential 1s/2s/4s/... capped 30s with ±20% jitter.
+          // `!= null` so a provider-signaled 0ms (Retry-After: 0) is honored
+          // rather than falling through to exponential delay.
           let delay;
-          if (apiError instanceof RateLimitError && apiError.retryAfterMs) {
+          if (apiError instanceof RateLimitError && apiError.retryAfterMs != null) {
             delay = Math.min(60000, apiError.retryAfterMs);
           } else {
             const base = Math.min(30000, 1000 * Math.pow(2, retryCount));

--- a/lib/analyzer/rateLimit.js
+++ b/lib/analyzer/rateLimit.js
@@ -9,6 +9,7 @@
 
 export const ARXIV_DOWNLOAD_DELAY_MS = 5000;
 export const ARXIV_MAX_RETRY_AFTER_MS = 60000;
+export const LLM_MAX_RETRY_AFTER_MS = 60000;
 
 export function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -66,6 +67,61 @@ export class ArxivDownloadThrottle {
 }
 
 /**
+ * Per-provider barrier for LLM rate-limit cascades. When one of N concurrent
+ * workers (filter / score / pdf / etc.) catches a 429 from a provider, ALL
+ * other workers for that provider should pause too — Gemini's RPM cap is
+ * project-scoped, not connection-scoped, so siblings are about to trip the
+ * same limit. Workers `await barrier.acquire()` before each LLM call;
+ * acquire() returns immediately when not rate-limited and waits otherwise.
+ *
+ * Mirrors ArxivDownloadThrottle.rateLimited() shape so the worker-pool
+ * barrierFor opt-in can plug either kind of barrier in.
+ */
+export class LLMRateLimitBarrier {
+  constructor() {
+    this.pausedUntil = 0;
+  }
+
+  async acquire() {
+    const now = Date.now();
+    const waitMs = this.pausedUntil - now;
+    if (waitMs > 0) {
+      await sleep(waitMs);
+    }
+  }
+
+  rateLimited({ retryAfterMs }) {
+    const capped = Math.min(Math.max(0, retryAfterMs ?? 0), LLM_MAX_RETRY_AFTER_MS);
+    const target = Date.now() + capped;
+    if (target > this.pausedUntil) this.pausedUntil = target;
+  }
+
+  // Test helper: forcibly clear pause state.
+  reset() {
+    this.pausedUntil = 0;
+  }
+}
+
+// Module-level per-provider barriers. Workers across all stages (filter,
+// score, rescore, pdf, etc.) share the same barrier per provider, so a
+// 429 in any stage pauses every other stage that's hitting that provider.
+const _llmBarriers = new Map();
+export function getLLMBarrier(provider) {
+  const key = (provider ?? 'unknown').toLowerCase();
+  let barrier = _llmBarriers.get(key);
+  if (!barrier) {
+    barrier = new LLMRateLimitBarrier();
+    _llmBarriers.set(key, barrier);
+  }
+  return barrier;
+}
+
+// Test helper: clear all barriers between tests.
+export function _resetLLMBarriers() {
+  _llmBarriers.clear();
+}
+
+/**
  * N-wide worker pool for client-side fan-out of independent tasks. Tasks are
  * fed from an input array; workers pull the next index atomically.
  *
@@ -79,10 +135,20 @@ export class ArxivDownloadThrottle {
  * shared state). Wrap run() in try/catch if you want fail-fast semantics.
  */
 export class AnalysisWorkerPool {
-  constructor({ concurrency = 3, cacheWarmup = false, abortSignal = null } = {}) {
+  constructor({
+    concurrency = 3,
+    cacheWarmup = false,
+    abortSignal = null,
+    // Optional `(task) => barrier | null` callback. When set, each worker
+    // awaits the returned barrier's acquire() before invoking workerFn.
+    // Used by LLM stages to share the per-provider LLMRateLimitBarrier so
+    // a 429 in any worker pauses all siblings.
+    barrierFor = null,
+  } = {}) {
     this.concurrency = Math.max(1, Math.min(20, concurrency));
     this.cacheWarmup = cacheWarmup;
     this.abortSignal = abortSignal;
+    this.barrierFor = barrierFor;
   }
 
   /**
@@ -127,6 +193,15 @@ export class AnalysisWorkerPool {
       const idx = claim();
       if (idx < 0) break;
       try {
+        // Optional barrier acquire — used by LLM stages to coordinate on
+        // rate-limit pauses. No-op when barrierFor is null or returns null.
+        if (this.barrierFor) {
+          const barrier = this.barrierFor(tasks[idx]);
+          if (barrier && typeof barrier.acquire === 'function') {
+            await barrier.acquire();
+            if (this.abortSignal?.aborted) break;
+          }
+        }
         await workerFn(tasks[idx], idx);
       } catch (err) {
         // Task-level error: log and move on. The workerFn is expected to

--- a/lib/llm/ProviderError.js
+++ b/lib/llm/ProviderError.js
@@ -1,0 +1,37 @@
+// Typed error thrown by lib/llm/callModel.js when an LLM provider returns
+// a non-2xx response. Preserves HTTP status, the raw provider error body,
+// and a parsed retryAfterMs (when the provider tells us how long to wait)
+// end-to-end through the API route catch + client error handler — so users
+// see "google: RESOURCE_EXHAUSTED" instead of the bare "Failed to filter
+// papers", and so the rate-limit barrier can pause the whole worker pool
+// for the right duration.
+//
+// Pattern: route's catch checks `error instanceof ProviderError`, returns
+// `res.status(error.status).json({error, retryAfterMs, details, provider})`.
+// Client's `if (!response.ok)` branch reads `data.retryAfterMs` and throws
+// a RateLimitError when status is 429 or 503.
+
+export class ProviderError extends Error {
+  constructor({ provider, status, providerErrorBody, retryAfterMs, message }) {
+    super(message ?? `${provider} request failed (${status})`);
+    this.name = 'ProviderError';
+    this.provider = provider;
+    this.status = status;
+    this.providerErrorBody = providerErrorBody;
+    this.retryAfterMs = retryAfterMs ?? null;
+  }
+}
+
+// Route-helper: returns true if the error was a ProviderError and was
+// translated into an HTTP response. Callers fall through to their generic
+// 500 catch when this returns false.
+export function sendProviderErrorResponse(res, error) {
+  if (!(error instanceof ProviderError)) return false;
+  res.status(error.status).json({
+    error: error.message,
+    retryAfterMs: error.retryAfterMs ?? null,
+    details: error.providerErrorBody ?? error.message,
+    provider: error.provider,
+  });
+  return true;
+}

--- a/lib/llm/callModel.js
+++ b/lib/llm/callModel.js
@@ -1,5 +1,7 @@
 import { loadFixture } from './fixtures.js';
 import { getProviderConfig } from './providers.js';
+import { ProviderError } from './ProviderError.js';
+import { parseProviderRetryAfter } from './retryAfter.js';
 
 /**
  * Call an LLM provider.
@@ -63,11 +65,19 @@ export async function callModel(input, options = { mode: 'live' }) {
   if (input.pdfBase64) logPayload.hasPdf = true;
   console.log(`Sending request to ${providerLabel}:`, logPayload);
 
-  // Helper: log raw provider error server-side, throw sanitized message to caller.
-  // Prevents API keys or sensitive provider details from reaching the browser.
-  function throwProviderError(provider, status, rawText) {
-    console.error(`[${provider}] API error ${status}:`, rawText);
-    throw new Error(`${provider} request failed (${status})`);
+  // Helper: log raw provider error server-side, throw a typed ProviderError
+  // with HTTP status + parsed Retry-After preserved end-to-end. The route
+  // catch propagates `status`/`retryAfterMs` to the client, which classifies
+  // 429/503 as RateLimitError so makeRobustAPICall can honor Retry-After
+  // and signal the per-provider rate-limit barrier.
+  function throwProviderError(provider, response, rawText) {
+    console.error(`[${provider}] API error ${response.status}:`, rawText);
+    throw new ProviderError({
+      provider,
+      status: response.status,
+      providerErrorBody: rawText,
+      retryAfterMs: parseProviderRetryAfter(provider, response, rawText),
+    });
   }
 
   if (effectiveInput.provider === 'anthropic') {
@@ -87,7 +97,7 @@ export async function callModel(input, options = { mode: 'live' }) {
       body: JSON.stringify(req.body),
     });
     if (!response.ok) {
-      throwProviderError('anthropic', response.status, await response.text());
+      throwProviderError('anthropic', response, await response.text());
     }
     const json = await response.json();
     const result = parseAnthropicResponse(json);
@@ -108,7 +118,7 @@ export async function callModel(input, options = { mode: 'live' }) {
       body: JSON.stringify(req.body),
     });
     if (!response.ok) {
-      throwProviderError('google', response.status, await response.text());
+      throwProviderError('google', response, await response.text());
     }
     const json = await response.json();
     return parseGoogleResponse(json, { expectStructured: !!effectiveInput.structuredOutput });
@@ -139,7 +149,7 @@ export async function callModel(input, options = { mode: 'live' }) {
       body: JSON.stringify(req.body),
     });
     if (!response.ok) {
-      throwProviderError('openai', response.status, await response.text());
+      throwProviderError('openai', response, await response.text());
     }
     const json = await response.json();
     const result = effectiveInput.pdfBase64

--- a/lib/llm/retryAfter.js
+++ b/lib/llm/retryAfter.js
@@ -1,0 +1,63 @@
+// Provider-portable Retry-After parsing.
+//
+// Header form (Anthropic, OpenAI):
+//   Retry-After: 30                          → 30 seconds
+//   Retry-After: Wed, 21 Oct 2026 07:28:00 GMT → ms-from-now
+//
+// Body form (Google Gemini RESOURCE_EXHAUSTED): Google does NOT send
+// Retry-After headers. The retry guidance lives in the JSON error body:
+//   { error: { details: [
+//       { '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+//         retryDelay: '23s' }   // or '1.5s', '0.250s', etc.
+//   ] } }
+//
+// All helpers return milliseconds (number) or null when no usable signal
+// is present. Callers cap the returned value (typical cap: 60s) and fall
+// back to exponential backoff.
+
+export function parseRetryAfterHeader(header) {
+  if (!header) return null;
+  const asSeconds = parseInt(header, 10);
+  if (Number.isFinite(asSeconds) && asSeconds >= 0) return asSeconds * 1000;
+  const asDate = new Date(header);
+  if (!Number.isNaN(asDate.getTime())) {
+    return Math.max(0, asDate.getTime() - Date.now());
+  }
+  return null;
+}
+
+// Returns ms from a Google RetryInfo body, or null.
+//   parseGoogleRetryDelay('{"error":{"details":[{"@type":"...RetryInfo","retryDelay":"23s"}]}}') → 23000
+export function parseGoogleRetryDelay(rawText) {
+  if (!rawText || typeof rawText !== 'string') return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    return null;
+  }
+  const details = parsed?.error?.details;
+  if (!Array.isArray(details)) return null;
+  const RETRY_INFO_TYPE = 'type.googleapis.com/google.rpc.RetryInfo';
+  const info = details.find((d) => d?.['@type'] === RETRY_INFO_TYPE);
+  if (!info?.retryDelay) return null;
+  // Format is `<seconds>s`, possibly fractional (e.g. "1.5s", "0.250s").
+  const match = /^(\d+(?:\.\d+)?)s$/.exec(info.retryDelay);
+  if (!match) return null;
+  const seconds = Number(match[1]);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  return Math.round(seconds * 1000);
+}
+
+// Provider-aware dispatch. `response` is a Fetch Response; `rawText` is
+// the already-read body (since we can't read it twice). Returns ms or null.
+export function parseProviderRetryAfter(provider, response, rawText) {
+  if (provider === 'google') {
+    return parseGoogleRetryDelay(rawText);
+  }
+  // Anthropic + OpenAI both send Retry-After header on 429 (and 529 for
+  // Anthropic overload). OpenAI uses delta-seconds; Anthropic uses
+  // delta-seconds. Both formats handled by parseRetryAfterHeader.
+  const header = response?.headers?.get?.('retry-after');
+  return parseRetryAfterHeader(header);
+}

--- a/lib/persistence/safeStorage.js
+++ b/lib/persistence/safeStorage.js
@@ -1,0 +1,55 @@
+// Shared localStorage quota-handling primitives. Lifted from hooks/useBriefing.js
+// (introduced for the briefings tiered store, 2026-04-21) so the analyzer
+// session persistence (hooks/useAnalyzerPersistence.js) can reuse the same
+// fallback ladder.
+//
+// Pattern: try setItem → on QuotaExceededError, fall back. Callers decide what
+// "fall back" means via stripHeavy + their own retry loop (see persistHistory
+// / persistCurrent in useBriefing.js for the canonical example).
+
+export function isQuotaError(err) {
+  if (!err) return false;
+  // Name varies across browsers; numeric codes 22 / 1014 are the legacy forms.
+  const name = err.name || '';
+  return (
+    name === 'QuotaExceededError' ||
+    name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    err.code === 22 ||
+    err.code === 1014
+  );
+}
+
+// Returns true on success, false on quota failure. Re-throws non-quota errors
+// so callers don't silently swallow them.
+export function safeSetItem(key, value) {
+  if (typeof window === 'undefined') return true;
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch (err) {
+    if (isQuotaError(err)) return false;
+    throw err;
+  }
+}
+
+// Drop a list of keys from a shallow object copy. Supports dotted paths
+// ("results.allPapers") so callers can target nested heavy fields without
+// rebuilding the object themselves.
+export function stripFields(entry, fields) {
+  const out = JSON.parse(JSON.stringify(entry));
+  for (const path of fields) {
+    const segments = path.split('.');
+    let cursor = out;
+    for (let i = 0; i < segments.length - 1; i++) {
+      if (cursor == null || typeof cursor !== 'object') {
+        cursor = null;
+        break;
+      }
+      cursor = cursor[segments[i]];
+    }
+    if (cursor && typeof cursor === 'object') {
+      delete cursor[segments[segments.length - 1]];
+    }
+  }
+  return out;
+}

--- a/lib/session/buildHotEntry.js
+++ b/lib/session/buildHotEntry.js
@@ -1,0 +1,70 @@
+// Builds the localStorage hot-tier blob for analyzer session state. Heavy
+// fields (results.allPapers, results.scoredPapers, full filterResults arrays)
+// live in the filesystem cold tier at reports/sessions/<id>.json; the hot
+// blob stays under ~600 KB so localStorage quota is never the limit.
+//
+// Shape preserved for CLI compat (cli/run-analysis.js reads
+// appState.results.finalRanking). The full session is fetched lazily on
+// mount via GET /api/sessions/<id> when sessionId is present.
+
+export function buildHotEntry({
+  config,
+  sessionId,
+  finalRanking,
+  filterResults,
+  processingTiming,
+  testState,
+  podcastDuration,
+  notebookLMModel,
+  notebookLMContent,
+  password,
+  isAuthenticated,
+}) {
+  return {
+    config,
+    sessionId,
+    results: {
+      // Drop allPapers + scoredPapers from the hot tier — re-derivable from
+      // the cold-tier file and from lib/arxiv/cache.js. Keep finalRanking
+      // (top 30 with deepAnalysis, ~300-500 KB) so the post-refresh "view
+      // results" path renders without a network roundtrip.
+      finalRanking: finalRanking ?? [],
+    },
+    filterResults: {
+      total: filterResults?.total ?? 0,
+      yesCount: filterResults?.yes?.length ?? 0,
+      maybeCount: filterResults?.maybe?.length ?? 0,
+      noCount: filterResults?.no?.length ?? 0,
+    },
+    processingTiming,
+    testState,
+    notebookLM: {
+      duration: podcastDuration,
+      model: notebookLMModel,
+      content: notebookLMContent,
+    },
+    password: isAuthenticated ? password : '',
+  };
+}
+
+// Builds the full session payload posted to the cold tier. Includes
+// allPapers + scoredPapers + full filterResults verdicts so a refresh can
+// restore the exact pre-refresh UI state.
+export function buildColdEntry({ sessionId, results, filterResults, processingTiming }) {
+  return {
+    id: sessionId,
+    timestamp: Date.now(),
+    results: {
+      allPapers: results?.allPapers ?? [],
+      scoredPapers: results?.scoredPapers ?? [],
+      finalRanking: results?.finalRanking ?? [],
+    },
+    filterResults: {
+      total: filterResults?.total ?? 0,
+      yes: filterResults?.yes ?? [],
+      maybe: filterResults?.maybe ?? [],
+      no: filterResults?.no ?? [],
+    },
+    processingTiming,
+  };
+}

--- a/lib/session/buildHotEntry.js
+++ b/lib/session/buildHotEntry.js
@@ -49,12 +49,14 @@ export function buildHotEntry({
 
 // Builds the full session payload posted to the cold tier. Includes
 // allPapers + scoredPapers + full filterResults verdicts so a refresh can
-// restore the exact pre-refresh UI state.
+// restore the exact pre-refresh UI state. Spreads `results` so other slice
+// fields (e.g. `failedPapers` from scoreAbstracts) survive the round-trip.
 export function buildColdEntry({ sessionId, results, filterResults, processingTiming }) {
   return {
     id: sessionId,
     timestamp: Date.now(),
     results: {
+      ...(results ?? {}),
       allPapers: results?.allPapers ?? [],
       scoredPapers: results?.scoredPapers ?? [],
       finalRanking: results?.finalRanking ?? [],

--- a/pages/api/analyze-pdf-quick.js
+++ b/pages/api/analyze-pdf-quick.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { callModel } from '../../lib/llm/callModel.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import { MODEL_REGISTRY } from '../../utils/models.js';
 
 export default async function handler(req, res) {
@@ -92,6 +93,7 @@ export default async function handler(req, res) {
       tokensOut: response.tokensOut,
     });
   } catch (err) {
+    if (sendProviderErrorResponse(res, err)) return;
     res.status(500).json({ error: 'quick summary failed', details: String(err?.message ?? err) });
   }
 }

--- a/pages/api/analyze-pdf.js
+++ b/pages/api/analyze-pdf.js
@@ -3,6 +3,8 @@ import { extractJsonFromLlmOutput } from '../../utils/json.js';
 import { loadRubricPrompt } from '../../lib/llm/loadRubricPrompt.js';
 import { resolveApiKey } from '../../lib/llm/resolveApiKey.js';
 import { ArxivDownloadThrottle } from '../../lib/analyzer/rateLimit.js';
+import { parseRetryAfterHeader as parseRetryAfterMs } from '../../lib/llm/retryAfter.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import { MODEL_REGISTRY } from '../../utils/models.js';
 import path from 'path';
 import fs from 'fs';
@@ -17,18 +19,6 @@ import fs from 'fs';
 // so module state is shared across all requests. If this ever moves to a
 // serverless/edge deployment, replace with a shared-store implementation.
 const downloadThrottle = new ArxivDownloadThrottle();
-
-// Parse a Retry-After header (either delta-seconds or HTTP-date format) into ms.
-function parseRetryAfterMs(header) {
-  if (!header) return null;
-  const asSeconds = parseInt(header, 10);
-  if (Number.isFinite(asSeconds) && asSeconds >= 0) return asSeconds * 1000;
-  const asDate = new Date(header);
-  if (!Number.isNaN(asDate.getTime())) {
-    return Math.max(0, asDate.getTime() - Date.now());
-  }
-  return null;
-}
 
 // Playwright is an optional dependency. It's only needed when arXiv serves a
 // reCAPTCHA page instead of the PDF bytes. If it's not installed, we return a
@@ -467,6 +457,7 @@ export default async function handler(req, res) {
       });
     }
     console.error('Error analyzing PDF:', error);
+    if (sendProviderErrorResponse(res, error)) return;
     res.status(500).json({
       error: 'Failed to analyze PDF',
       details: error.message,

--- a/pages/api/check-briefing.js
+++ b/pages/api/check-briefing.js
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import { callModel } from '../../lib/llm/callModel.js';
 import { resolveApiKey } from '../../lib/llm/resolveApiKey.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import { MODEL_REGISTRY } from '../../utils/models.js';
 
 // Zod schema for the hallucination check structured output
@@ -282,6 +283,7 @@ export default async function handler(req, res) {
       originalValidationErrors: firstErrors,
     });
   } catch (err) {
+    if (sendProviderErrorResponse(res, err)) return;
     res.status(500).json({ error: 'check-briefing failed', details: String(err?.message ?? err) });
   }
 }

--- a/pages/api/quick-filter.js
+++ b/pages/api/quick-filter.js
@@ -1,6 +1,7 @@
 import { callModel } from '../../lib/llm/callModel.js';
 import { extractJsonFromLlmOutput } from '../../utils/json.js';
 import { loadRubricPrompt } from '../../lib/llm/loadRubricPrompt.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import { MODEL_REGISTRY } from '../../utils/models.js';
 
 function checkPassword(password) {
@@ -262,6 +263,7 @@ export default async function handler(req, res) {
     });
   } catch (error) {
     console.error('Error filtering papers:', error);
+    if (sendProviderErrorResponse(res, error)) return;
     res.status(500).json({
       error: 'Failed to filter papers',
       details: error.message,

--- a/pages/api/rescore-abstracts.js
+++ b/pages/api/rescore-abstracts.js
@@ -1,6 +1,7 @@
 import { callModel } from '../../lib/llm/callModel.js';
 import { extractJsonFromLlmOutput } from '../../utils/json.js';
 import { loadRubricPrompt } from '../../lib/llm/loadRubricPrompt.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import { MODEL_REGISTRY } from '../../utils/models.js';
 
 function checkPassword(password) {
@@ -248,6 +249,7 @@ export default async function handler(req, res) {
     });
   } catch (error) {
     console.error('Error rescoring abstracts:', error);
+    if (sendProviderErrorResponse(res, error)) return;
     res.status(500).json({
       error: 'Failed to rescore abstracts',
       details: error.message,

--- a/pages/api/score-abstracts.js
+++ b/pages/api/score-abstracts.js
@@ -1,6 +1,7 @@
 import { callModel } from '../../lib/llm/callModel.js';
 import { extractJsonFromLlmOutput } from '../../utils/json.js';
 import { loadRubricPrompt } from '../../lib/llm/loadRubricPrompt.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import { MODEL_REGISTRY } from '../../utils/models.js';
 
 function checkPassword(password) {
@@ -234,6 +235,7 @@ export default async function handler(req, res) {
     });
   } catch (error) {
     console.error('Error scoring abstracts:', error);
+    if (sendProviderErrorResponse(res, error)) return;
     res.status(500).json({
       error: 'Failed to score abstracts',
       details: error.message,

--- a/pages/api/sessions/[id].js
+++ b/pages/api/sessions/[id].js
@@ -1,0 +1,66 @@
+import path from 'path';
+import fs from 'fs/promises';
+
+const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function getSessionsDir() {
+  const base = process.env.APARTURE_REPORTS_DIR || path.join(process.cwd(), 'reports');
+  return path.join(base, 'sessions');
+}
+
+function validateId(id) {
+  return typeof id === 'string' && ID_PATTERN.test(id);
+}
+
+function resolveFile(id) {
+  const dir = getSessionsDir();
+  const filePath = path.join(dir, `${id}.json`);
+  if (!filePath.startsWith(dir + path.sep)) return null;
+  return { dir, filePath };
+}
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+
+  if (!validateId(id)) {
+    return res.status(400).json({ error: 'Invalid id' });
+  }
+  const resolved = resolveFile(id);
+  if (!resolved) {
+    return res.status(400).json({ error: 'Invalid path' });
+  }
+
+  if (req.method === 'GET') {
+    const password = req.query.password;
+    if (password !== process.env.ACCESS_PASSWORD) {
+      return res.status(401).json({ error: 'Invalid password' });
+    }
+    try {
+      const raw = await fs.readFile(resolved.filePath, 'utf8');
+      return res.status(200).json(JSON.parse(raw));
+    } catch (err) {
+      if (err.code === 'ENOENT') return res.status(404).json({ error: 'Not found' });
+      console.error('[sessions GET] read failed:', err);
+      return res.status(500).json({ error: err.message });
+    }
+  }
+
+  if (req.method === 'DELETE') {
+    const password = req.query.password;
+    if (password !== process.env.ACCESS_PASSWORD) {
+      return res.status(401).json({ error: 'Invalid password' });
+    }
+    try {
+      await fs.unlink(resolved.filePath);
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        console.error('[sessions DELETE] unlink failed:', err);
+        return res.status(500).json({ error: err.message });
+      }
+      // Idempotent: missing file is fine.
+    }
+    return res.status(200).json({ ok: true });
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/api/sessions/index.js
+++ b/pages/api/sessions/index.js
@@ -11,6 +11,15 @@
 import path from 'path';
 import fs from 'fs/promises';
 
+// Next.js' default API body limit is 1mb; a full session payload (allPapers
+// + scoredPapers + full filterResults verdicts) for a 600+-paper run is in
+// the 7-15 MB range. Raise the limit so cold-tier saves don't 413.
+export const config = {
+  api: {
+    bodyParser: { sizeLimit: '20mb' },
+  },
+};
+
 const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 function getSessionsDir() {

--- a/pages/api/sessions/index.js
+++ b/pages/api/sessions/index.js
@@ -1,0 +1,79 @@
+// Sessions cold tier — analyzer-state filesystem store, parallel to
+// pages/api/briefings/index.js. Heavy session data (results.allPapers,
+// results.scoredPapers, full filterResults arrays) lives here so the
+// localStorage hot tier (`arxivAnalyzerState`) stays under quota.
+//
+// Each save effect rewrites the entire session entry (POST is idempotent +
+// atomic via tmp + rename). No PATCH endpoint — the hot tier keeps a
+// finalRanking summary, and the cold tier is a write-many target. Phase 2
+// migrates the base path to ~/aparture/sessions/ via APARTURE_REPORTS_DIR.
+
+import path from 'path';
+import fs from 'fs/promises';
+
+const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function getSessionsDir() {
+  const base = process.env.APARTURE_REPORTS_DIR || path.join(process.cwd(), 'reports');
+  return path.join(base, 'sessions');
+}
+
+function validateId(id) {
+  return typeof id === 'string' && ID_PATTERN.test(id);
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const password = req.query.password;
+    if (password !== process.env.ACCESS_PASSWORD) {
+      return res.status(401).json({ error: 'Invalid password' });
+    }
+    const dir = getSessionsDir();
+    try {
+      const files = await fs.readdir(dir);
+      const ids = files
+        .filter((f) => f.endsWith('.json') && !f.endsWith('.tmp'))
+        .map((f) => f.slice(0, -'.json'.length));
+      return res.status(200).json({ ids });
+    } catch (err) {
+      if (err.code === 'ENOENT') return res.status(200).json({ ids: [] });
+      console.error('[sessions GET list] readdir failed:', err);
+      return res.status(500).json({ error: err.message });
+    }
+  }
+
+  if (req.method === 'POST') {
+    const { password, entry } = req.body ?? {};
+    if (password !== process.env.ACCESS_PASSWORD) {
+      return res.status(401).json({ error: 'Invalid password' });
+    }
+    if (!entry || typeof entry !== 'object') {
+      return res.status(400).json({ error: 'Missing entry' });
+    }
+    if (!validateId(entry.id)) {
+      return res.status(400).json({ error: 'Invalid id' });
+    }
+
+    const dir = getSessionsDir();
+    const filePath = path.join(dir, `${entry.id}.json`);
+    if (!filePath.startsWith(dir + path.sep)) {
+      return res.status(400).json({ error: 'Invalid path' });
+    }
+
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      const serialized = JSON.stringify(entry, null, 2);
+      const tmpPath = `${filePath}.tmp`;
+      await fs.writeFile(tmpPath, serialized, 'utf8');
+      await fs.rename(tmpPath, filePath);
+      return res
+        .status(200)
+        .json({ id: entry.id, bytesWritten: Buffer.byteLength(serialized, 'utf8') });
+    } catch (err) {
+      console.error('[sessions POST] write failed:', err);
+      return res.status(500).json({ error: err.message });
+    }
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/api/suggest-profile.js
+++ b/pages/api/suggest-profile.js
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import { callModel } from '../../lib/llm/callModel.js';
 import { resolveApiKey } from '../../lib/llm/resolveApiKey.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import {
   renderSuggestPrompt,
   validateNonOverlappingChanges,
@@ -354,6 +355,7 @@ export default async function handler(req, res) {
       ...(firstErrors ? { originalValidationErrors: firstErrors } : {}),
     });
   } catch (err) {
+    if (sendProviderErrorResponse(res, err)) return;
     res.status(500).json({ error: 'suggest-profile failed', details: String(err?.message ?? err) });
   }
 }

--- a/pages/api/synthesize.js
+++ b/pages/api/synthesize.js
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { callModel } from '../../lib/llm/callModel.js';
 import { resolveApiKey } from '../../lib/llm/resolveApiKey.js';
+import { sendProviderErrorResponse } from '../../lib/llm/ProviderError.js';
 import { renderSynthesisPrompt } from '../../lib/synthesis/renderPrompt.js';
 import { toJsonSchema } from '../../lib/synthesis/schema.js';
 import { validateBriefing } from '../../lib/synthesis/validator.js';
@@ -162,6 +163,7 @@ export default async function handler(req, res) {
       originalValidationErrors: validation.errors,
     });
   } catch (err) {
+    if (sendProviderErrorResponse(res, err)) return;
     res.status(500).json({ error: 'synthesis failed', details: String(err?.message ?? err) });
   }
 }

--- a/tests/integration/sessions-api.test.js
+++ b/tests/integration/sessions-api.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import handler from '../../pages/api/sessions/index.js';
+import idHandler from '../../pages/api/sessions/[id].js';
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'aparture-sessions-'));
+  process.env.APARTURE_REPORTS_DIR = tmpDir;
+  process.env.ACCESS_PASSWORD = 'test-pw';
+});
+
+afterEach(async () => {
+  delete process.env.APARTURE_REPORTS_DIR;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function mockReqRes(body, method = 'POST', query = {}) {
+  const req = { method, body, query };
+  const state = { statusCode: 200, jsonBody: undefined };
+  const res = {
+    status(code) {
+      state.statusCode = code;
+      return this;
+    },
+    json(data) {
+      state.jsonBody = data;
+      return this;
+    },
+  };
+  return { req, res, getResponse: () => state };
+}
+
+const sampleEntry = () => ({
+  id: 'sess-abc123',
+  timestamp: 1745244000000,
+  results: {
+    allPapers: [{ id: '2504.00001', title: 'P1', abstract: 'abstract 1' }],
+    scoredPapers: [{ id: '2504.00001', title: 'P1', relevanceScore: 7 }],
+    finalRanking: [{ id: '2504.00001', title: 'P1', finalScore: 8 }],
+  },
+  filterResults: { total: 1, yes: [{ id: '2504.00001' }], maybe: [], no: [] },
+  processingTiming: { startTime: '2026-05-07T09:00:00Z' },
+});
+
+describe('POST /api/sessions', () => {
+  it('writes a session file and returns { id, bytesWritten }', async () => {
+    const entry = sampleEntry();
+    const { req, res, getResponse } = mockReqRes({ password: 'test-pw', entry });
+
+    await handler(req, res);
+
+    const { statusCode, jsonBody } = getResponse();
+    expect(statusCode).toBe(200);
+    expect(jsonBody.id).toBe(entry.id);
+    expect(jsonBody.bytesWritten).toBeGreaterThan(0);
+
+    const filePath = path.join(tmpDir, 'sessions', `${entry.id}.json`);
+    const stored = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    expect(stored).toEqual(entry);
+  });
+
+  it('rejects wrong password with 401', async () => {
+    const { req, res, getResponse } = mockReqRes({ password: 'wrong', entry: sampleEntry() });
+    await handler(req, res);
+    expect(getResponse().statusCode).toBe(401);
+  });
+
+  it('rejects missing entry with 400', async () => {
+    const { req, res, getResponse } = mockReqRes({ password: 'test-pw' });
+    await handler(req, res);
+    expect(getResponse().statusCode).toBe(400);
+  });
+
+  it('rejects invalid id with 400 (path traversal defense)', async () => {
+    const entry = { ...sampleEntry(), id: '../evil' };
+    const { req, res, getResponse } = mockReqRes({ password: 'test-pw', entry });
+    await handler(req, res);
+    expect(getResponse().statusCode).toBe(400);
+  });
+});
+
+describe('GET /api/sessions', () => {
+  it('returns empty list when sessions dir does not exist', async () => {
+    const { req, res, getResponse } = mockReqRes(undefined, 'GET', { password: 'test-pw' });
+    await handler(req, res);
+    const { statusCode, jsonBody } = getResponse();
+    expect(statusCode).toBe(200);
+    expect(jsonBody).toEqual({ ids: [] });
+  });
+
+  it('lists session ids after writes', async () => {
+    const entry = sampleEntry();
+    {
+      const { req, res } = mockReqRes({ password: 'test-pw', entry });
+      await handler(req, res);
+    }
+    const { req, res, getResponse } = mockReqRes(undefined, 'GET', { password: 'test-pw' });
+    await handler(req, res);
+    expect(getResponse().jsonBody.ids).toContain(entry.id);
+  });
+});
+
+describe('GET /api/sessions/[id]', () => {
+  it('returns 404 for missing session', async () => {
+    const { req, res, getResponse } = mockReqRes(undefined, 'GET', {
+      password: 'test-pw',
+      id: 'sess-missing',
+    });
+    await idHandler(req, res);
+    expect(getResponse().statusCode).toBe(404);
+  });
+
+  it('returns the session entry after POST', async () => {
+    const entry = sampleEntry();
+    {
+      const { req, res } = mockReqRes({ password: 'test-pw', entry });
+      await handler(req, res);
+    }
+    const { req, res, getResponse } = mockReqRes(undefined, 'GET', {
+      password: 'test-pw',
+      id: entry.id,
+    });
+    await idHandler(req, res);
+    expect(getResponse().statusCode).toBe(200);
+    expect(getResponse().jsonBody).toEqual(entry);
+  });
+});
+
+describe('DELETE /api/sessions/[id]', () => {
+  it('removes the session file', async () => {
+    const entry = sampleEntry();
+    {
+      const { req, res } = mockReqRes({ password: 'test-pw', entry });
+      await handler(req, res);
+    }
+    const { req, res, getResponse } = mockReqRes(undefined, 'DELETE', {
+      password: 'test-pw',
+      id: entry.id,
+    });
+    await idHandler(req, res);
+    expect(getResponse().statusCode).toBe(200);
+
+    const filePath = path.join(tmpDir, 'sessions', `${entry.id}.json`);
+    await expect(fs.access(filePath)).rejects.toBeDefined();
+  });
+
+  it('is idempotent (DELETE of missing returns 200)', async () => {
+    const { req, res, getResponse } = mockReqRes(undefined, 'DELETE', {
+      password: 'test-pw',
+      id: 'sess-missing',
+    });
+    await idHandler(req, res);
+    expect(getResponse().statusCode).toBe(200);
+  });
+});

--- a/tests/unit/analyzer/llmBarrier.test.js
+++ b/tests/unit/analyzer/llmBarrier.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  LLMRateLimitBarrier,
+  AnalysisWorkerPool,
+  getLLMBarrier,
+  _resetLLMBarriers,
+  LLM_MAX_RETRY_AFTER_MS,
+} from '../../../lib/analyzer/rateLimit.js';
+
+beforeEach(() => {
+  _resetLLMBarriers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('LLMRateLimitBarrier', () => {
+  it('acquire() returns immediately when not rate-limited', async () => {
+    const b = new LLMRateLimitBarrier();
+    const before = Date.now();
+    await b.acquire();
+    expect(Date.now() - before).toBeLessThan(50);
+  });
+
+  it('acquire() waits at least retryAfterMs after rateLimited()', async () => {
+    vi.useFakeTimers();
+    const b = new LLMRateLimitBarrier();
+    b.rateLimited({ retryAfterMs: 5000 });
+    let resolved = false;
+    const p = b.acquire().then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(4500);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(600);
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('caps retry-after at LLM_MAX_RETRY_AFTER_MS', async () => {
+    vi.useFakeTimers();
+    const b = new LLMRateLimitBarrier();
+    b.rateLimited({ retryAfterMs: 600000 }); // 10 minutes
+    let resolved = false;
+    const p = b.acquire().then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(LLM_MAX_RETRY_AFTER_MS + 100);
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('multiple rateLimited() calls take the longest pause (not additive)', async () => {
+    vi.useFakeTimers();
+    const b = new LLMRateLimitBarrier();
+    b.rateLimited({ retryAfterMs: 2000 });
+    b.rateLimited({ retryAfterMs: 5000 });
+    b.rateLimited({ retryAfterMs: 1000 }); // shorter, ignored
+    let resolved = false;
+    const p = b.acquire().then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(4900);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(200);
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('handles null/undefined retryAfterMs gracefully', () => {
+    const b = new LLMRateLimitBarrier();
+    expect(() => b.rateLimited({ retryAfterMs: null })).not.toThrow();
+    expect(() => b.rateLimited({ retryAfterMs: undefined })).not.toThrow();
+    expect(b.pausedUntil).toBeLessThanOrEqual(Date.now());
+  });
+});
+
+describe('getLLMBarrier', () => {
+  it('returns the same barrier instance for the same provider', () => {
+    const a1 = getLLMBarrier('google');
+    const a2 = getLLMBarrier('google');
+    expect(a1).toBe(a2);
+  });
+
+  it('is case-insensitive on provider key', () => {
+    const a = getLLMBarrier('Anthropic');
+    const b = getLLMBarrier('anthropic');
+    expect(a).toBe(b);
+  });
+
+  it('returns separate barriers per provider', () => {
+    const g = getLLMBarrier('google');
+    const a = getLLMBarrier('anthropic');
+    const o = getLLMBarrier('openai');
+    expect(g).not.toBe(a);
+    expect(a).not.toBe(o);
+  });
+});
+
+describe('AnalysisWorkerPool barrierFor integration', () => {
+  it('awaits the barrier before each workerFn call when barrierFor is set', async () => {
+    vi.useFakeTimers();
+    const barrier = new LLMRateLimitBarrier();
+    barrier.rateLimited({ retryAfterMs: 3000 });
+    const seen = [];
+    const pool = new AnalysisWorkerPool({
+      concurrency: 2,
+      barrierFor: () => barrier,
+    });
+    const tasks = [{ id: 'a' }, { id: 'b' }];
+    const workerFn = async (task) => {
+      seen.push(task.id);
+    };
+    const runPromise = pool.run(tasks, workerFn);
+    // Before timer advances, no workers should have run.
+    expect(seen).toEqual([]);
+    await vi.advanceTimersByTimeAsync(3100);
+    await runPromise;
+    expect(seen).toContain('a');
+    expect(seen).toContain('b');
+  });
+
+  it('does not block when barrierFor returns null', async () => {
+    const seen = [];
+    const pool = new AnalysisWorkerPool({
+      concurrency: 2,
+      barrierFor: () => null,
+    });
+    await pool.run([{ id: 'a' }], async (t) => {
+      seen.push(t.id);
+    });
+    expect(seen).toEqual(['a']);
+  });
+
+  it('preserves existing behavior when barrierFor is not set', async () => {
+    const seen = [];
+    const pool = new AnalysisWorkerPool({ concurrency: 2 });
+    await pool.run([{ id: 'a' }, { id: 'b' }], async (t) => {
+      seen.push(t.id);
+    });
+    expect(seen.sort()).toEqual(['a', 'b']);
+  });
+});

--- a/tests/unit/analyzer/parseRouteError.test.js
+++ b/tests/unit/analyzer/parseRouteError.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { parseRouteError, RateLimitError } from '../../../lib/analyzer/RateLimitError.js';
+
+function mockResponse({ status, body }) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => (typeof body === 'string' ? JSON.parse(body) : body),
+  };
+}
+
+describe('parseRouteError', () => {
+  it('throws RateLimitError on 429 with retryAfterMs from body', async () => {
+    let caught;
+    try {
+      await parseRouteError(
+        mockResponse({
+          status: 429,
+          body: {
+            error: 'google: rate limited (429)',
+            details: 'RESOURCE_EXHAUSTED',
+            retryAfterMs: 23000,
+            provider: 'google',
+          },
+        }),
+        'google'
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RateLimitError);
+    expect(caught.provider).toBe('google');
+    expect(caught.status).toBe(429);
+    expect(caught.retryAfterMs).toBe(23000);
+    expect(caught.message).toMatch(/retry in 23s/);
+  });
+
+  it('throws RateLimitError on 503 even without retryAfterMs', async () => {
+    let caught;
+    try {
+      await parseRouteError(
+        mockResponse({ status: 503, body: { error: 'overloaded' } }),
+        'anthropic'
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RateLimitError);
+    expect(caught.status).toBe(503);
+    expect(caught.retryAfterMs).toBeNull();
+  });
+
+  it('throws plain Error with details for non-rate-limit failures', async () => {
+    let caught;
+    try {
+      await parseRouteError(
+        mockResponse({
+          status: 400,
+          body: { error: 'Invalid request', details: 'google: invalid argument' },
+        }),
+        'google'
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(RateLimitError);
+    // Surfaces actual provider message, not the generic route error
+    expect(caught.message).toBe('google: invalid argument');
+  });
+
+  it('uses fallback provider when body lacks one', async () => {
+    let caught;
+    try {
+      await parseRouteError(mockResponse({ status: 429, body: { error: 'limit' } }), 'openai');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught.provider).toBe('openai');
+  });
+
+  it('falls back to status-based message when body is empty/non-JSON', async () => {
+    const res = {
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('not json');
+      },
+    };
+    let caught;
+    try {
+      await parseRouteError(res, 'google');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught.message).toContain('500');
+  });
+});

--- a/tests/unit/hooks/useAnalyzerPersistence.test.js
+++ b/tests/unit/hooks/useAnalyzerPersistence.test.js
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import {
+  useAnalyzerPersistence,
+  readInitialConfig,
+  DEFAULT_CONFIG,
+} from '../../../hooks/useAnalyzerPersistence.js';
+
+const STORAGE_KEY = 'arxivAnalyzerState';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ id: 'sess-x', bytesWritten: 0 }),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeProps(overrides = {}) {
+  return {
+    config: { selectedCategories: ['cs.AI'], filterModel: 'gemini-3-flash' },
+    results: { allPapers: [], scoredPapers: [], finalRanking: [] },
+    filterResults: { total: 0, yes: [], maybe: [], no: [] },
+    processingTiming: {},
+    testState: {},
+    podcastDuration: '15min',
+    notebookLMModel: 'standard',
+    notebookLMContent: null,
+    password: 'test-pw',
+    isAuthenticated: true,
+    setResults: vi.fn(),
+    setFilterResults: vi.fn(),
+    setProcessingTiming: vi.fn(),
+    setTestState: vi.fn(),
+    setPodcastDuration: vi.fn(),
+    setNotebookLMModel: vi.fn(),
+    setNotebookLMContent: vi.fn(),
+    setPassword: vi.fn(),
+    setIsAuthenticated: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('readInitialConfig', () => {
+  it('returns DEFAULT_CONFIG when storage is empty', () => {
+    expect(readInitialConfig()).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('restores config from a tiered hot blob', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        config: { ...DEFAULT_CONFIG, selectedCategories: ['stat.ML'] },
+        sessionId: 'sess-1',
+      })
+    );
+    expect(readInitialConfig().selectedCategories).toEqual(['stat.ML']);
+  });
+
+  it('restores config from a legacy blob (results inline)', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        config: { ...DEFAULT_CONFIG, daysBack: 7 },
+        results: { allPapers: [{ id: '1' }] },
+      })
+    );
+    expect(readInitialConfig().daysBack).toBe(7);
+  });
+});
+
+describe('useAnalyzerPersistence — DEFAULT_CONFIG', () => {
+  it('default maxRetries is 4 (5 attempts) for the new exponential-backoff retry ladder', () => {
+    expect(DEFAULT_CONFIG.maxRetries).toBe(4);
+  });
+});
+
+describe('useAnalyzerPersistence — save effect', () => {
+  it('does NOT persist heavy fields (allPapers, scoredPapers, full verdicts) to localStorage', async () => {
+    vi.useFakeTimers();
+    const props = makeProps({
+      results: {
+        allPapers: [{ id: '1', abstract: 'a'.repeat(1000) }],
+        scoredPapers: [{ id: '1', score: 7 }],
+        finalRanking: [{ id: '1', finalScore: 8 }],
+      },
+      filterResults: {
+        total: 100,
+        yes: [{ id: '1' }, { id: '2' }],
+        maybe: [{ id: '3' }],
+        no: [{ id: '4' }],
+      },
+    });
+    renderHook(() => useAnalyzerPersistence(props));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY));
+    expect(stored.results.allPapers).toBeUndefined();
+    expect(stored.results.scoredPapers).toBeUndefined();
+    expect(stored.results.finalRanking).toEqual([{ id: '1', finalScore: 8 }]);
+    expect(stored.filterResults.yes).toBeUndefined();
+    expect(stored.filterResults.yesCount).toBe(2);
+    expect(stored.filterResults.maybeCount).toBe(1);
+    expect(stored.filterResults.noCount).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it('POSTs full payload to /api/sessions (cold tier)', async () => {
+    vi.useFakeTimers();
+    const props = makeProps({
+      results: {
+        allPapers: [{ id: '1' }],
+        scoredPapers: [{ id: '1' }],
+        finalRanking: [],
+      },
+    });
+    renderHook(() => useAnalyzerPersistence(props));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const postCall = global.fetch.mock.calls.find(
+      (call) => call[0] === '/api/sessions' && call[1]?.method === 'POST'
+    );
+    expect(postCall).toBeDefined();
+    const body = JSON.parse(postCall[1].body);
+    expect(body.password).toBe('test-pw');
+    expect(body.entry.id).toMatch(/^[a-zA-Z0-9_-]+$/);
+    expect(body.entry.results.allPapers).toEqual([{ id: '1' }]);
+    vi.useRealTimers();
+  });
+
+  it('survives QuotaExceededError without crashing (warns instead)', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const err = new DOMException('quota', 'QuotaExceededError');
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw err;
+    });
+
+    const props = makeProps({
+      results: {
+        allPapers: [{ id: '1' }],
+        scoredPapers: [],
+        finalRanking: [],
+      },
+    });
+    renderHook(() => useAnalyzerPersistence(props));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.some((call) => /quota/i.test(call[0]))).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('reuses sessionId across saves so cold writes overwrite in place', async () => {
+    vi.useFakeTimers();
+    const props = makeProps({
+      results: { allPapers: [{ id: '1' }], scoredPapers: [], finalRanking: [] },
+    });
+    const { rerender } = renderHook((p) => useAnalyzerPersistence(p), { initialProps: props });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    const firstId = JSON.parse(window.localStorage.getItem(STORAGE_KEY)).sessionId;
+
+    rerender(
+      makeProps({
+        ...props,
+        results: { allPapers: [{ id: '1' }, { id: '2' }], scoredPapers: [], finalRanking: [] },
+      })
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    const secondId = JSON.parse(window.localStorage.getItem(STORAGE_KEY)).sessionId;
+    expect(secondId).toBe(firstId);
+    vi.useRealTimers();
+  });
+
+  it('skips cold POST when not authenticated', async () => {
+    vi.useFakeTimers();
+    const props = makeProps({
+      isAuthenticated: false,
+      password: '',
+      results: { allPapers: [{ id: '1' }], scoredPapers: [], finalRanking: [] },
+    });
+    renderHook(() => useAnalyzerPersistence(props));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const postCall = global.fetch.mock.calls.find(
+      (call) => call[0] === '/api/sessions' && call[1]?.method === 'POST'
+    );
+    expect(postCall).toBeUndefined();
+    vi.useRealTimers();
+  });
+});
+
+describe('useAnalyzerPersistence — load effect', () => {
+  it('restores legacy (full inline) blob without fetching cold tier', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        config: DEFAULT_CONFIG,
+        results: {
+          allPapers: [{ id: '1', title: 't' }],
+          scoredPapers: [],
+          finalRanking: [],
+        },
+        filterResults: { total: 1, yes: [{ id: '1' }], maybe: [], no: [] },
+      })
+    );
+    const props = makeProps();
+    renderHook(() => useAnalyzerPersistence(props));
+
+    await waitFor(() => {
+      expect(props.setResults).toHaveBeenCalled();
+    });
+    expect(props.setResults).toHaveBeenCalledWith(
+      expect.objectContaining({ allPapers: [{ id: '1', title: 't' }] })
+    );
+    // No cold-tier GET because allPapers was inline
+    const getCall = global.fetch.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].startsWith('/api/sessions/')
+    );
+    expect(getCall).toBeUndefined();
+  });
+
+  it('lazy-loads cold tier when hot blob has sessionId but no allPapers', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        config: DEFAULT_CONFIG,
+        sessionId: 'sess-abc',
+        results: { finalRanking: [{ id: '1', finalScore: 8 }] },
+        filterResults: { total: 100, yesCount: 5, maybeCount: 3, noCount: 92 },
+        password: 'test-pw',
+      })
+    );
+    global.fetch.mockImplementation(async (url) => {
+      if (url.startsWith('/api/sessions/sess-abc')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            id: 'sess-abc',
+            results: {
+              allPapers: [{ id: '1' }, { id: '2' }],
+              scoredPapers: [{ id: '1', score: 9 }],
+              finalRanking: [{ id: '1', finalScore: 8 }],
+            },
+            filterResults: {
+              total: 100,
+              yes: [{ id: '1' }],
+              maybe: [{ id: '3' }],
+              no: [{ id: '4' }],
+            },
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    });
+
+    const props = makeProps();
+    renderHook(() => useAnalyzerPersistence(props));
+
+    await waitFor(() => {
+      const setResultsArgs = props.setResults.mock.calls.flat();
+      const lastCall = setResultsArgs[setResultsArgs.length - 1];
+      const resolved = typeof lastCall === 'function' ? lastCall({ finalRanking: [] }) : lastCall;
+      expect(resolved.allPapers).toEqual([{ id: '1' }, { id: '2' }]);
+    });
+  });
+});

--- a/tests/unit/llm/ProviderError.test.js
+++ b/tests/unit/llm/ProviderError.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ProviderError } from '../../../lib/llm/ProviderError.js';
+
+describe('ProviderError', () => {
+  it('preserves provider, status, body, retryAfterMs', () => {
+    const err = new ProviderError({
+      provider: 'google',
+      status: 429,
+      providerErrorBody: '{"error":{"status":"RESOURCE_EXHAUSTED"}}',
+      retryAfterMs: 23000,
+    });
+    expect(err.provider).toBe('google');
+    expect(err.status).toBe(429);
+    expect(err.providerErrorBody).toBe('{"error":{"status":"RESOURCE_EXHAUSTED"}}');
+    expect(err.retryAfterMs).toBe(23000);
+    expect(err.name).toBe('ProviderError');
+  });
+
+  it('defaults message to "<provider> request failed (<status>)"', () => {
+    const err = new ProviderError({ provider: 'anthropic', status: 503 });
+    expect(err.message).toBe('anthropic request failed (503)');
+  });
+
+  it('accepts a custom message', () => {
+    const err = new ProviderError({
+      provider: 'openai',
+      status: 400,
+      message: 'invalid argument',
+    });
+    expect(err.message).toBe('invalid argument');
+  });
+
+  it('treats missing retryAfterMs as null', () => {
+    const err = new ProviderError({ provider: 'openai', status: 500 });
+    expect(err.retryAfterMs).toBeNull();
+  });
+
+  it('is catchable as Error and instanceof check works', () => {
+    try {
+      throw new ProviderError({ provider: 'google', status: 429 });
+    } catch (err) {
+      expect(err instanceof Error).toBe(true);
+      expect(err instanceof ProviderError).toBe(true);
+    }
+  });
+});

--- a/tests/unit/llm/callModel-errors.test.js
+++ b/tests/unit/llm/callModel-errors.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { callModel } from '../../../lib/llm/callModel.js';
+import { ProviderError } from '../../../lib/llm/ProviderError.js';
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchResponse({ status, headers = {}, body = '' }) {
+  vi.stubGlobal('fetch', async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return headers[name.toLowerCase()] ?? null;
+      },
+    },
+    text: async () => body,
+    json: async () => JSON.parse(body || '{}'),
+  }));
+}
+
+describe('callModel error path — ProviderError with status + retryAfterMs', () => {
+  it('throws ProviderError with status 429 + retryAfterMs from Anthropic Retry-After header', async () => {
+    mockFetchResponse({
+      status: 429,
+      headers: { 'retry-after': '45' },
+      body: '{"type":"error","error":{"type":"rate_limit_error","message":"too many"}}',
+    });
+
+    let caught;
+    try {
+      await callModel(
+        {
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          prompt: 'hi',
+          apiKey: 'sk-test',
+        },
+        { mode: 'live' }
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProviderError);
+    expect(caught.provider).toBe('anthropic');
+    expect(caught.status).toBe(429);
+    expect(caught.retryAfterMs).toBe(45000);
+    expect(caught.providerErrorBody).toContain('rate_limit_error');
+  });
+
+  it('throws ProviderError with retryAfterMs from Google RetryInfo body', async () => {
+    mockFetchResponse({
+      status: 429,
+      headers: {},
+      body: JSON.stringify({
+        error: {
+          status: 'RESOURCE_EXHAUSTED',
+          details: [{ '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay: '23s' }],
+        },
+      }),
+    });
+
+    let caught;
+    try {
+      await callModel(
+        { provider: 'google', model: 'gemini-3-flash', prompt: 'hi', apiKey: 'k' },
+        { mode: 'live' }
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProviderError);
+    expect(caught.provider).toBe('google');
+    expect(caught.status).toBe(429);
+    expect(caught.retryAfterMs).toBe(23000);
+  });
+
+  it('throws ProviderError with status 503 + null retryAfterMs when no signal present', async () => {
+    mockFetchResponse({
+      status: 503,
+      headers: {},
+      body: '{"error":"service unavailable"}',
+    });
+
+    let caught;
+    try {
+      await callModel(
+        { provider: 'openai', model: 'gpt-5', prompt: 'hi', apiKey: 'sk-test' },
+        { mode: 'live' }
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProviderError);
+    expect(caught.provider).toBe('openai');
+    expect(caught.status).toBe(503);
+    expect(caught.retryAfterMs).toBeNull();
+  });
+});

--- a/tests/unit/llm/retryAfter.test.js
+++ b/tests/unit/llm/retryAfter.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseRetryAfterHeader,
+  parseGoogleRetryDelay,
+  parseProviderRetryAfter,
+} from '../../../lib/llm/retryAfter.js';
+
+describe('parseRetryAfterHeader', () => {
+  it('parses delta-seconds form', () => {
+    expect(parseRetryAfterHeader('30')).toBe(30000);
+    expect(parseRetryAfterHeader('0')).toBe(0);
+    expect(parseRetryAfterHeader('120')).toBe(120000);
+  });
+
+  it('parses HTTP-date form as ms-from-now', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-10-21T07:27:00Z'));
+    const ms = parseRetryAfterHeader('Wed, 21 Oct 2026 07:28:00 GMT');
+    expect(ms).toBe(60000);
+    vi.useRealTimers();
+  });
+
+  it('returns null for null/empty input', () => {
+    expect(parseRetryAfterHeader(null)).toBeNull();
+    expect(parseRetryAfterHeader(undefined)).toBeNull();
+    expect(parseRetryAfterHeader('')).toBeNull();
+  });
+
+  it('returns null for unparseable strings', () => {
+    expect(parseRetryAfterHeader('not a number or date')).toBeNull();
+  });
+
+  it('clamps negative HTTP-date deltas to 0', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-10-21T07:30:00Z'));
+    const ms = parseRetryAfterHeader('Wed, 21 Oct 2026 07:28:00 GMT');
+    expect(ms).toBe(0);
+    vi.useRealTimers();
+  });
+});
+
+describe('parseGoogleRetryDelay', () => {
+  it('parses RetryInfo body with whole-second delay', () => {
+    const body = JSON.stringify({
+      error: {
+        status: 'RESOURCE_EXHAUSTED',
+        details: [{ '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay: '23s' }],
+      },
+    });
+    expect(parseGoogleRetryDelay(body)).toBe(23000);
+  });
+
+  it('parses fractional-second delay', () => {
+    const body = JSON.stringify({
+      error: {
+        details: [{ '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay: '1.5s' }],
+      },
+    });
+    expect(parseGoogleRetryDelay(body)).toBe(1500);
+  });
+
+  it('returns null when no RetryInfo present', () => {
+    const body = JSON.stringify({
+      error: {
+        status: 'INVALID_ARGUMENT',
+        details: [{ '@type': 'type.googleapis.com/google.rpc.BadRequest' }],
+      },
+    });
+    expect(parseGoogleRetryDelay(body)).toBeNull();
+  });
+
+  it('returns null for unparseable JSON', () => {
+    expect(parseGoogleRetryDelay('not json')).toBeNull();
+  });
+
+  it('returns null for empty/null input', () => {
+    expect(parseGoogleRetryDelay(null)).toBeNull();
+    expect(parseGoogleRetryDelay('')).toBeNull();
+  });
+
+  it('returns null when retryDelay is missing the trailing s', () => {
+    const body = JSON.stringify({
+      error: {
+        details: [{ '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay: '23' }],
+      },
+    });
+    expect(parseGoogleRetryDelay(body)).toBeNull();
+  });
+});
+
+describe('parseProviderRetryAfter', () => {
+  function mockResponse(headers = {}) {
+    return {
+      headers: {
+        get(name) {
+          return headers[name.toLowerCase()] ?? null;
+        },
+      },
+    };
+  }
+
+  it('uses header path for anthropic', () => {
+    const ms = parseProviderRetryAfter('anthropic', mockResponse({ 'retry-after': '45' }), null);
+    expect(ms).toBe(45000);
+  });
+
+  it('uses header path for openai', () => {
+    const ms = parseProviderRetryAfter('openai', mockResponse({ 'retry-after': '12' }), null);
+    expect(ms).toBe(12000);
+  });
+
+  it('uses body path for google (ignores headers)', () => {
+    const body = JSON.stringify({
+      error: {
+        details: [{ '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay: '7s' }],
+      },
+    });
+    const ms = parseProviderRetryAfter(
+      'google',
+      mockResponse({ 'retry-after': '99' }), // would-be header is ignored
+      body
+    );
+    expect(ms).toBe(7000);
+  });
+
+  it('returns null when no signal present', () => {
+    expect(parseProviderRetryAfter('anthropic', mockResponse({}), null)).toBeNull();
+    expect(parseProviderRetryAfter('google', mockResponse({}), '{}')).toBeNull();
+  });
+});

--- a/tests/unit/llm/sendProviderErrorResponse.test.js
+++ b/tests/unit/llm/sendProviderErrorResponse.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { ProviderError, sendProviderErrorResponse } from '../../../lib/llm/ProviderError.js';
+
+function mockRes() {
+  const state = { statusCode: undefined, body: undefined };
+  return {
+    status(code) {
+      state.statusCode = code;
+      return this;
+    },
+    json(data) {
+      state.body = data;
+      return this;
+    },
+    _state: state,
+  };
+}
+
+describe('sendProviderErrorResponse', () => {
+  it('returns true and writes 429 + retryAfterMs + details for a Google ProviderError', () => {
+    const res = mockRes();
+    const err = new ProviderError({
+      provider: 'google',
+      status: 429,
+      providerErrorBody: '{"error":{"status":"RESOURCE_EXHAUSTED"}}',
+      retryAfterMs: 23000,
+    });
+    expect(sendProviderErrorResponse(res, err)).toBe(true);
+    expect(res._state.statusCode).toBe(429);
+    expect(res._state.body.error).toContain('google');
+    expect(res._state.body.retryAfterMs).toBe(23000);
+    expect(res._state.body.details).toContain('RESOURCE_EXHAUSTED');
+    expect(res._state.body.provider).toBe('google');
+  });
+
+  it('returns true and writes 503 with null retryAfterMs', () => {
+    const res = mockRes();
+    const err = new ProviderError({ provider: 'openai', status: 503 });
+    expect(sendProviderErrorResponse(res, err)).toBe(true);
+    expect(res._state.statusCode).toBe(503);
+    expect(res._state.body.retryAfterMs).toBeNull();
+  });
+
+  it('returns false for a plain Error (caller falls through to 500)', () => {
+    const res = mockRes();
+    expect(sendProviderErrorResponse(res, new Error('something else'))).toBe(false);
+    expect(res._state.statusCode).toBeUndefined();
+  });
+
+  it('returns false for null/undefined error', () => {
+    const res = mockRes();
+    expect(sendProviderErrorResponse(res, null)).toBe(false);
+    expect(sendProviderErrorResponse(res, undefined)).toBe(false);
+  });
+});

--- a/tests/unit/persistence/safeStorage.test.js
+++ b/tests/unit/persistence/safeStorage.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { isQuotaError, safeSetItem, stripFields } from '../../../lib/persistence/safeStorage.js';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isQuotaError', () => {
+  it('detects QuotaExceededError by name', () => {
+    const err = new Error('quota');
+    err.name = 'QuotaExceededError';
+    expect(isQuotaError(err)).toBe(true);
+  });
+
+  it('detects Firefox NS_ERROR_DOM_QUOTA_REACHED by name', () => {
+    const err = new Error('quota');
+    err.name = 'NS_ERROR_DOM_QUOTA_REACHED';
+    expect(isQuotaError(err)).toBe(true);
+  });
+
+  it('detects legacy code 22 / 1014', () => {
+    expect(isQuotaError({ code: 22 })).toBe(true);
+    expect(isQuotaError({ code: 1014 })).toBe(true);
+  });
+
+  it('rejects unrelated errors', () => {
+    expect(isQuotaError(new Error('boom'))).toBe(false);
+    expect(isQuotaError(null)).toBe(false);
+    expect(isQuotaError(undefined)).toBe(false);
+  });
+});
+
+describe('safeSetItem', () => {
+  it('returns true on successful write', () => {
+    expect(safeSetItem('k', 'v')).toBe(true);
+    expect(window.localStorage.getItem('k')).toBe('v');
+  });
+
+  it('returns false on QuotaExceededError without throwing', () => {
+    const err = new DOMException('quota', 'QuotaExceededError');
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw err;
+    });
+    expect(safeSetItem('k', 'v')).toBe(false);
+  });
+
+  it('rethrows non-quota errors', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('other');
+    });
+    expect(() => safeSetItem('k', 'v')).toThrow('other');
+  });
+});
+
+describe('stripFields', () => {
+  it('drops top-level fields', () => {
+    const out = stripFields({ a: 1, b: 2, c: 3 }, ['b']);
+    expect(out).toEqual({ a: 1, c: 3 });
+  });
+
+  it('drops nested fields via dotted path', () => {
+    const out = stripFields(
+      { results: { allPapers: [1, 2, 3], finalRanking: [9] }, config: { x: 1 } },
+      ['results.allPapers']
+    );
+    expect(out).toEqual({ results: { finalRanking: [9] }, config: { x: 1 } });
+  });
+
+  it('does not mutate input', () => {
+    const input = { results: { allPapers: [1] } };
+    stripFields(input, ['results.allPapers']);
+    expect(input.results.allPapers).toEqual([1]);
+  });
+
+  it('is a no-op for missing paths', () => {
+    const out = stripFields({ a: 1 }, ['b.c.d']);
+    expect(out).toEqual({ a: 1 });
+  });
+});

--- a/tests/unit/session/buildHotEntry.test.js
+++ b/tests/unit/session/buildHotEntry.test.js
@@ -98,4 +98,19 @@ describe('buildColdEntry', () => {
     expect(cold.timestamp).toBeGreaterThanOrEqual(before);
     expect(cold.timestamp).toBeLessThanOrEqual(Date.now());
   });
+
+  it('preserves additional `results` slice fields like failedPapers', () => {
+    const cold = buildColdEntry({
+      sessionId: 'sess-1',
+      results: {
+        allPapers: [{ id: '1' }],
+        scoredPapers: [],
+        finalRanking: [],
+        failedPapers: [{ id: '2', failureReason: 'Scored as 0 relevance' }],
+      },
+    });
+    expect(cold.results.failedPapers).toEqual([
+      { id: '2', failureReason: 'Scored as 0 relevance' },
+    ]);
+  });
 });

--- a/tests/unit/session/buildHotEntry.test.js
+++ b/tests/unit/session/buildHotEntry.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { buildHotEntry, buildColdEntry } from '../../../lib/session/buildHotEntry.js';
+
+describe('buildHotEntry', () => {
+  it('drops allPapers + scoredPapers from results', () => {
+    const hot = buildHotEntry({
+      config: { x: 1 },
+      sessionId: 'sess-1',
+      finalRanking: [{ id: '1', title: 't' }],
+      filterResults: { total: 10, yes: [], maybe: [], no: [] },
+    });
+    expect(hot.results.finalRanking).toEqual([{ id: '1', title: 't' }]);
+    expect(hot.results.allPapers).toBeUndefined();
+    expect(hot.results.scoredPapers).toBeUndefined();
+  });
+
+  it('reduces filterResults to counts', () => {
+    const hot = buildHotEntry({
+      filterResults: {
+        total: 100,
+        yes: [{ id: '1' }, { id: '2' }],
+        maybe: [{ id: '3' }],
+        no: [{ id: '4' }, { id: '5' }, { id: '6' }],
+      },
+    });
+    expect(hot.filterResults).toEqual({
+      total: 100,
+      yesCount: 2,
+      maybeCount: 1,
+      noCount: 3,
+    });
+  });
+
+  it('zeros out password when not authenticated', () => {
+    const hot = buildHotEntry({ password: 'secret', isAuthenticated: false });
+    expect(hot.password).toBe('');
+  });
+
+  it('keeps password when authenticated', () => {
+    const hot = buildHotEntry({ password: 'secret', isAuthenticated: true });
+    expect(hot.password).toBe('secret');
+  });
+
+  it('preserves config + sessionId verbatim', () => {
+    const config = { selectedCategories: ['cs.AI'], filterModel: 'gemini-3.1-flash-lite' };
+    const hot = buildHotEntry({ config, sessionId: 'sess-abc' });
+    expect(hot.config).toBe(config);
+    expect(hot.sessionId).toBe('sess-abc');
+  });
+
+  it('handles missing fields gracefully', () => {
+    const hot = buildHotEntry({});
+    expect(hot.results).toEqual({ finalRanking: [] });
+    expect(hot.filterResults).toEqual({
+      total: 0,
+      yesCount: 0,
+      maybeCount: 0,
+      noCount: 0,
+    });
+  });
+});
+
+describe('buildColdEntry', () => {
+  it('includes allPapers + scoredPapers + finalRanking', () => {
+    const cold = buildColdEntry({
+      sessionId: 'sess-1',
+      results: {
+        allPapers: [{ id: '1' }],
+        scoredPapers: [{ id: '1', score: 7 }],
+        finalRanking: [{ id: '1', finalScore: 8 }],
+      },
+      filterResults: { total: 1, yes: [{ id: '1' }], maybe: [], no: [] },
+    });
+    expect(cold.id).toBe('sess-1');
+    expect(cold.results.allPapers).toHaveLength(1);
+    expect(cold.results.scoredPapers).toHaveLength(1);
+    expect(cold.results.finalRanking).toHaveLength(1);
+  });
+
+  it('keeps full filterResults verdicts (yes/maybe/no arrays)', () => {
+    const cold = buildColdEntry({
+      sessionId: 'sess-1',
+      filterResults: {
+        total: 3,
+        yes: [{ id: '1' }],
+        maybe: [{ id: '2' }],
+        no: [{ id: '3' }],
+      },
+    });
+    expect(cold.filterResults.yes).toHaveLength(1);
+    expect(cold.filterResults.maybe).toHaveLength(1);
+    expect(cold.filterResults.no).toHaveLength(1);
+  });
+
+  it('stamps a timestamp', () => {
+    const before = Date.now();
+    const cold = buildColdEntry({ sessionId: 'sess-1' });
+    expect(cold.timestamp).toBeGreaterThanOrEqual(before);
+    expect(cold.timestamp).toBeLessThanOrEqual(Date.now());
+  });
+});


### PR DESCRIPTION
Squashes two crash modes that block setup on real-world runs:

1. QuotaExceededError on `arxivAnalyzerState`. The debounced save effect
   blindly stringified a 12-18 MB session blob (full allPapers + scoredPapers
   + filterResults). Now mirrors the briefings tiered store: hot tier in
   localStorage carries only config + sessionId + finalRanking + filter
   counts (~600 KB max); cold tier writes the full payload to
   reports/sessions/<id>.json via new POST /api/sessions. safeSetItem helper
   lifted from useBriefing.js to lib/persistence/safeStorage.js for reuse.
   No legacy migration — old single-key blobs are read as-is and shrunk on
   the next save.

2. Bare "Failed to filter papers" errors during Stage 2. HTTP status, the
   raw provider error body, and a parsed Retry-After are now plumbed
   end-to-end via a typed ProviderError thrown from callModel, propagated
   through every LLM route's catch (sendProviderErrorResponse), and parsed
   client-side into a RateLimitError on 429/503. makeRobustAPICall honors
   Retry-After (cap 60s) or falls back to exponential+jittered backoff (cap
   30s); a per-provider LLMRateLimitBarrier pauses every concurrent worker
   for the same provider when one trips a 429, preventing the cascade
   that turns one rate-limit hit into 15. Default maxRetries raised 1 → 4.

Also adds a pre-flight warning when free-tier Gemini Flash-Lite + the
configured concurrency × batch count is likely to exceed 60 RPM, plus an
end-of-stage activity-log line per stage with rate-limited count broken out.

https://claude.ai/code/session_01Vpn6XLiHBYAxurGXt7ar5w